### PR TITLE
CMRNLP-80: Add env vars to mcp server terraform

### DIFF
--- a/terraform/modules/application/mcp-server.tf
+++ b/terraform/modules/application/mcp-server.tf
@@ -227,6 +227,34 @@ resource "aws_ecs_task_definition" "mcp" {
         {
           name  = "ENVIRONMENT_NAME"
           value = var.environment_name
+        },
+        {
+          name  = "DATABASE_SECRET_ID"
+          value = var.database_secret_arn
+        },
+        {
+          name  = "CMR_URL"
+          value = var.cmr_url
+        },
+        {
+          name  = "EMBEDDINGS_TABLE"
+          value = var.embeddings_table
+        },
+        {
+          name  = "ASSOCIATIONS_TABLE"
+          value = var.associations_table
+        },
+        {
+          name  = "LANGFUSE_BASE_URL"
+          value = var.langfuse_host
+        },
+        {
+          name  = "LANGFUSE_PUBLIC_KEY"
+          value = var.langfuse_public_key
+        },
+        {
+          name  = "REDIS_SECRET_ID"
+          value = aws_secretsmanager_secret.redis.arn
         }
       ]
 


### PR DESCRIPTION
This PR adds missing env variables required for MCP server deployement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend infrastructure configuration to enable integration with database systems, content management platforms, embeddings processing, data associations, Redis caching, and application observability and monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->