### PR TITLE
CMRNLP-80: Fixes permissions and adds missing security group

### DIFF
--- a/terraform/application/main.tf
+++ b/terraform/application/main.tf
@@ -231,6 +231,17 @@ resource "aws_security_group_rule" "lambda_to_database" {
   description              = "PostgreSQL from embedding lambda"
 }
 
+# Allow MCP server to connect to database
+resource "aws_security_group_rule" "mcp_server_to_database" {
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = module.application.mcp_server_security_group_id
+  security_group_id        = data.terraform_remote_state.database.outputs.security_group_id
+  description              = "PostgreSQL from MCP server"
+}
+
 # SSM Parameters for cross-stack references (queue URLs)
 resource "aws_ssm_parameter" "ingest_queue_url" {
   name        = "${var.environment_name}-ingest-queue-url"

--- a/terraform/modules/application/mcp-server.tf
+++ b/terraform/modules/application/mcp-server.tf
@@ -101,7 +101,9 @@ resource "aws_iam_role_policy" "mcp_task" {
         ]
         Resource = [
           "arn:aws:bedrock:*::foundation-model/amazon.titan-embed-*",
-          "arn:aws:bedrock:*:*:inference-profile/us.amazon.titan-embed-*"
+          "arn:aws:bedrock:*:*:inference-profile/us.amazon.titan-embed-*",
+          "arn:aws:bedrock:*::foundation-model/amazon.nova-pro-*",
+          "arn:aws:bedrock:*:*:inference-profile/us.amazon.nova-pro-*"
         ]
       },
       {

--- a/terraform/modules/application/outputs.tf
+++ b/terraform/modules/application/outputs.tf
@@ -52,3 +52,8 @@ output "embedding_lambda_security_group_id" {
   description = "Security group ID for the embedding Lambda"
   value       = aws_security_group.embedding_lambda.id
 }
+
+output "mcp_server_security_group_id" {
+  description = "Security group ID for the MCP server"
+  value       = aws_security_group.mcp_server.id
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured network security rules enabling MCP server connectivity to the database on port 5432
  * Expanded AI model support by adding Amazon Nova Pro foundation models and inference profiles to Bedrock resources
  * Exported MCP server security group identifier for infrastructure integration and resource linkage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->