### PR TITLE
CMRNLP-50: Filter out collections that do not contain granules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 
 # User-specific files
 tmp/
+temp/
 
 # Test coverage
 .coverage

--- a/README.md
+++ b/README.md
@@ -49,6 +49,42 @@ uv sync --extra dev
 
 ### Running Locally
 
+#### Local Database & Cache Configuration
+
+For local development, you can run PostgreSQL and Redis locally instead of using AWS services.
+
+**Database (PostgreSQL):**
+
+1. Start local PostgreSQL (with pgvector extension)
+2. Set environment variables in `.env`:
+
+   ```bash
+   DB_HOST=localhost
+   DATABASE_SECRET_ID=<your-aws-secret-id>  # Still needed for credentials
+   ```
+
+   The `DB_HOST` override allows you to connect to localhost while still using AWS Secrets Manager credentials.
+
+**Cache (Redis):**
+
+1. Start local Redis server
+2. Set environment variables in `.env`:
+
+   ```bash
+   REDIS_HOST=localhost
+   REDIS_PORT=6379              # Optional, defaults to 6379
+   REDIS_PASSWORD=<password>    # Optional for local dev
+   ```
+
+   When `REDIS_HOST` is set, the cache client uses local Redis instead of AWS Secrets Manager.
+
+**Production Mode:**
+
+- Database: Uses `DATABASE_SECRET_ID` to fetch connection URL from AWS Secrets Manager
+- Redis: Uses `REDIS_SECRET_ID` to fetch connection details from AWS Secrets Manager
+
+#### Starting the Server
+
 **HTTP Mode (recommended for development):**
 
 ```bash
@@ -81,11 +117,13 @@ uv run pytest tests/test_server.py
 ### MCP Inspector (Interactive Testing)
 
 1. Start the server:
+
    ```bash
    uv run server.py http
    ```
 
 2. Launch inspector:
+
    ```bash
    npx @modelcontextprotocol/inspector
    ```
@@ -133,6 +171,7 @@ https://cmr.earthdata.nasa.gov/mcp/sse
 ```
 
 Works with:
+
 - Claude Code CLI
 - VS Code MCP extensions
 - Any MCP-compatible client

--- a/lambdas/bootstrap/handler.py
+++ b/lambdas/bootstrap/handler.py
@@ -160,10 +160,10 @@ def handler(event: dict[str, Any], _context) -> dict[str, Any]:
     total_sent = 0
     total_errors = 0
 
-    for items in search_cmr(concept_type, search_params, page_size):
+    for page in search_cmr(concept_type, search_params, page_size):
         messages = []
 
-        for item in items:
+        for item in page.items:
             try:
                 msg = extract_concept_info(concept_type, item)
                 messages.append(msg)

--- a/tests/lambdas/test_bootstrap_handler.py
+++ b/tests/lambdas/test_bootstrap_handler.py
@@ -39,8 +39,8 @@ class TestSearchCmr:
         results = list(search_cmr("collection", {}, page_size=100))
 
         assert len(results) == 1
-        assert len(results[0]) == 2
-        assert results[0][0]["meta"]["concept-id"] == "C1234-PROV"
+        assert len(results[0].items) == 2
+        assert results[0].items[0]["meta"]["concept-id"] == "C1234-PROV"
 
     @responses.activate
     def test_search_cmr_paginates(self):
@@ -73,8 +73,8 @@ class TestSearchCmr:
         results = list(search_cmr("collection", {}, page_size=2))
 
         assert len(results) == 2
-        assert len(results[0]) == 2
-        assert len(results[1]) == 1
+        assert len(results[0].items) == 2
+        assert len(results[1].items) == 1
 
         # Verify second request included search-after header
         assert responses.calls[1].request.headers.get("CMR-Search-After") == '["token123"]'

--- a/tests/tools/discover_data/test_tool.py
+++ b/tests/tools/discover_data/test_tool.py
@@ -386,7 +386,8 @@ def test_describe_search_strategy_counts():
 
 
 def test_discover_data_error_handling(monkeypatch):
-    """Discover data should catch exceptions and return error status."""
+    """Discover data should catch unexpected exceptions, return a generic user-facing
+    message (not the internal error detail), and set status to error."""
     tool = _load_tool()
 
     # Create a mock that raises an exception
@@ -399,7 +400,40 @@ def test_discover_data_error_handling(monkeypatch):
     output = tool.discover_data(query)
 
     assert output["status"] == "error"
-    assert "Extraction failed" in output["error_message"]
+    assert output["error_message"] == "An unexpected error occurred. Please try your request again."
+    # Internal error detail must not be exposed to the caller
+    assert "Extraction failed" not in output["error_message"]
+
+
+def test_discover_data_granule_validation_error(monkeypatch):
+    """GranuleValidationError from validate_granule_availability should produce a
+    specific user-facing message distinct from the generic error handler."""
+    from tools.discover_data.utils.granule_availability import GranuleValidationError
+
+    tool = _load_tool()
+
+    temporal = TemporalConstraint(start_date=datetime(2020, 1, 1), end_date=datetime(2020, 12, 31))
+    spatial = SpatialConstraint()
+
+    monkeypatch.setattr(tool, "extract_constraints", lambda *_, **__: (temporal, spatial))
+    monkeypatch.setattr(tool, "search_all_entity_types", lambda *_, **__: [])
+    monkeypatch.setattr(tool, "score_and_rank_collections", lambda *_, **__: [])
+    monkeypatch.setattr(tool, "hydrate_collections", lambda *_, **__: [_make_collection("C1")])
+
+    def _raise_granule_error(*_):
+        raise GranuleValidationError("CMR granule validation failed for 1 of 1 collection(s)")
+
+    monkeypatch.setattr(tool, "validate_granule_availability", _raise_granule_error)
+
+    output = tool.discover_data(DiscoverDataInput(query="test"))
+
+    assert output["status"] == "error"
+    assert output["error_message"] == (
+        "Granule availability check failed due to a service error. "
+        "Please try your request again."
+    )
+    # Internal CMR detail must not be exposed to the caller
+    assert "CMR" not in output["error_message"]
 
 
 def test_discover_data_with_langfuse(monkeypatch):

--- a/tests/tools/discover_data/test_tool.py
+++ b/tests/tools/discover_data/test_tool.py
@@ -318,11 +318,30 @@ def test_determine_status_variants():
     direct = _make_collection("C1", match_type="direct")
     indirect = _make_collection("C2", match_type="via_variable")
 
-    assert tool._determine_status([], [], []) == tool.DiscoveryStatus.NO_RESULTS
-    assert tool._determine_status([direct], True, []) == tool.DiscoveryStatus.DISAMBIGUATION_NEEDED
-    assert tool._determine_status([indirect], False, []) == tool.DiscoveryStatus.INDIRECT_MATCHES
     assert (
-        tool._determine_status([direct], False, [{"match_type": "direct"}])
+        tool._determine_status([], [], [], all_filtered_by_granule_validation=True)
+        == tool.DiscoveryStatus.NO_GRANULES_IN_CONSTRAINTS
+    )
+    assert (
+        tool._determine_status([direct], False, [], all_filtered_by_granule_validation=True)
+        == tool.DiscoveryStatus.NO_GRANULES_IN_CONSTRAINTS
+    )
+    assert (
+        tool._determine_status([], [], [], all_filtered_by_granule_validation=False)
+        == tool.DiscoveryStatus.NO_RESULTS
+    )
+    assert (
+        tool._determine_status([direct], True, [], all_filtered_by_granule_validation=False)
+        == tool.DiscoveryStatus.DISAMBIGUATION_NEEDED
+    )
+    assert (
+        tool._determine_status([indirect], False, [], all_filtered_by_granule_validation=False)
+        == tool.DiscoveryStatus.INDIRECT_MATCHES
+    )
+    assert (
+        tool._determine_status(
+            [direct], False, [{"match_type": "direct"}], all_filtered_by_granule_validation=False
+        )
         == tool.DiscoveryStatus.COLLECTIONS_FOUND
     )
 
@@ -570,10 +589,22 @@ def test_end_to_end_disambiguation_with_user_refinement(monkeypatch):
             question_type="platform_preference",
             options=["Aqua", "Terra", "Landsat-8", "Landsat-9"],
             explanations={
-                "Aqua": "NASA satellite launched in 2002 carrying MODIS and other instruments for studying Earth's water cycle and clouds",
-                "Terra": "NASA satellite launched in 1999 carrying MODIS and other instruments for observing Earth's land, atmosphere, and oceans",
-                "Landsat-8": "USGS/NASA satellite launched in 2013 providing multispectral imagery with 30m resolution for land surface monitoring",
-                "Landsat-9": "USGS/NASA satellite launched in 2021 providing improved multispectral imagery with 30m resolution for land surface monitoring",
+                "Aqua": (
+                    "NASA satellite launched in 2002 carrying MODIS and other "
+                    "instruments for studying Earth's water cycle and clouds"
+                ),
+                "Terra": (
+                    "NASA satellite launched in 1999 carrying MODIS and other "
+                    "instruments for observing Earth's land, atmosphere, and oceans"
+                ),
+                "Landsat-8": (
+                    "USGS/NASA satellite launched in 2013 providing multispectral "
+                    "imagery with 30m resolution for land surface monitoring"
+                ),
+                "Landsat-9": (
+                    "USGS/NASA satellite launched in 2021 providing improved "
+                    "multispectral imagery with 30m resolution for land surface monitoring"
+                ),
             },
             recommendation=None,
         ),
@@ -704,3 +735,98 @@ def test_end_to_end_disambiguation_with_user_refinement(monkeypatch):
 
     # Verify context iteration incremented
     assert followup_output["search_context"]["search_iteration"] == 2
+
+
+def test_discover_data_with_granule_validation(monkeypatch):
+    """Test that granule validation phase filters out collections without granules."""
+    tool = _load_tool()
+
+    temporal = TemporalConstraint(start_date=datetime(2023, 1, 1), end_date=datetime(2023, 12, 31))
+    spatial = SpatialConstraint(wkt_geometry="POLYGON((0 0,1 0,1 1,0 1,0 0))")
+
+    monkeypatch.setattr(tool, "extract_constraints", lambda *_args, **_kwargs: (temporal, spatial))
+    monkeypatch.setattr(
+        tool,
+        "search_all_entity_types",
+        lambda *_args, **_kwargs: [
+            {"type": "collection", "similarity": 0.8, "match_type": "direct"}
+        ],
+    )
+
+    # Return two collections from hydration
+    collections_dict = [
+        _make_collection_dict("C1", metadata={"TemporalExtents": []}),
+        _make_collection_dict("C2", metadata={"TemporalExtents": []}),
+    ]
+    collections_match = [
+        _make_collection("C1"),
+        _make_collection("C2"),
+    ]
+    monkeypatch.setattr(
+        tool, "score_and_rank_collections", lambda *_args, **_kwargs: collections_dict
+    )
+    monkeypatch.setattr(tool, "hydrate_collections", lambda *_args, **_kwargs: collections_match)
+    monkeypatch.setattr(tool, "_describe_search_strategy", lambda *a, **k: "desc")
+    monkeypatch.setattr(tool, "should_expand_query", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(tool, "check_disambiguation", lambda cols: (False, []))
+    monkeypatch.setattr(tool, "filter_by_user_refinements", lambda cols, refs: cols)
+
+    # Mock validate_granule_availability to return only C1 (C2 filtered out)
+    def mock_validate(cols, _temporal, _spatial, _wkt):
+        # Only C1 has granules
+        return [c for c in cols if c.concept_id == "C1"]
+
+    monkeypatch.setattr(tool, "validate_granule_availability", mock_validate)
+
+    query = DiscoverDataInput(query="ocean data")
+    output = tool.discover_data(query)
+
+    # Should return only one collection
+    assert output["status"] == "collections_found"
+    assert len(output["collections"]) == 1
+    assert output["collections"][0]["concept_id"] == "C1"
+
+
+def test_discover_data_all_filtered_by_granule_validation(monkeypatch):
+    """Test NO_GRANULES_IN_CONSTRAINTS when all collections filtered by validation."""
+    tool = _load_tool()
+
+    temporal = TemporalConstraint(start_date=datetime(2023, 1, 1), end_date=datetime(2023, 12, 31))
+    spatial = SpatialConstraint(wkt_geometry="POLYGON((0 0,1 0,1 1,0 1,0 0))")
+
+    monkeypatch.setattr(tool, "extract_constraints", lambda *_args, **_kwargs: (temporal, spatial))
+    monkeypatch.setattr(
+        tool,
+        "search_all_entity_types",
+        lambda *_args, **_kwargs: [
+            {"type": "collection", "similarity": 0.8, "match_type": "direct"}
+        ],
+    )
+
+    # Return collections from hydration
+    collections_dict = [
+        _make_collection_dict("C1", metadata={"TemporalExtents": []}),
+        _make_collection_dict("C2", metadata={"TemporalExtents": []}),
+    ]
+    collections_match = [
+        _make_collection("C1"),
+        _make_collection("C2"),
+    ]
+    monkeypatch.setattr(
+        tool, "score_and_rank_collections", lambda *_args, **_kwargs: collections_dict
+    )
+    monkeypatch.setattr(tool, "hydrate_collections", lambda *_args, **_kwargs: collections_match)
+    monkeypatch.setattr(tool, "_describe_search_strategy", lambda *a, **k: "desc")
+    monkeypatch.setattr(tool, "should_expand_query", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(tool, "check_disambiguation", lambda cols: (False, []))
+    monkeypatch.setattr(tool, "filter_by_user_refinements", lambda cols, refs: cols)
+
+    # Mock validate_granule_availability to return empty list (all filtered)
+    monkeypatch.setattr(tool, "validate_granule_availability", lambda *args: [])
+
+    query = DiscoverDataInput(query="ocean data")
+    output = tool.discover_data(query)
+
+    # Should return NO_GRANULES_IN_CONSTRAINTS status
+    assert output["status"] == "no_granules_in_constraints"
+    assert not output["collections"]

--- a/tests/tools/discover_data/test_tool.py
+++ b/tests/tools/discover_data/test_tool.py
@@ -180,6 +180,13 @@ def test_discover_data_expansion_path(monkeypatch):
     monkeypatch.setattr(tool, "should_expand_query", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(tool, "_describe_search_strategy", lambda *a, **k: "desc")
 
+    def mock_validate_granules(collections, *_args, **_kwargs):
+        for col in collections:
+            col.granule_count = 100
+        return collections
+
+    monkeypatch.setattr(tool, "validate_granule_availability", mock_validate_granules)
+
     ctx_obj = object()
     monkeypatch.setattr(tool, "analyze_embedding_results", lambda results: ctx_obj)
     questions = [ClarifyingQuestion(question_id="q1"), ClarifyingQuestion(question_id="q2")]
@@ -226,6 +233,14 @@ def test_discover_data_disambiguation_path(monkeypatch):
     monkeypatch.setattr(tool, "_describe_search_strategy", lambda *a, **k: "desc")
     monkeypatch.setattr(tool, "should_expand_query", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(tool, "check_disambiguation", lambda cols: (False, []))
+
+    # Mock granule validation to return collections with granule counts
+    def mock_validate_granules(collections, *_args, **_kwargs):
+        for col in collections:
+            col.granule_count = 100
+        return collections
+
+    monkeypatch.setattr(tool, "validate_granule_availability", mock_validate_granules)
 
     # Ensure user refinements are applied
     applied = {}
@@ -297,6 +312,14 @@ def test_discover_data_with_disambiguation_questions(monkeypatch):
         ),
     ]
     monkeypatch.setattr(tool, "check_disambiguation", lambda cols: (True, disamb_questions))
+
+    # Mock granule validation to return collections with granule counts
+    def mock_validate_granules(collections, *_args, **_kwargs):
+        for col in collections:
+            col.granule_count = 100
+        return collections
+
+    monkeypatch.setattr(tool, "validate_granule_availability", mock_validate_granules)
 
     monkeypatch.setattr(tool, "filter_by_user_refinements", lambda cols, refs: cols)
 
@@ -416,6 +439,14 @@ def test_discover_data_with_langfuse(monkeypatch):
     monkeypatch.setattr(tool, "filter_by_user_refinements", lambda cols, refs: cols)
     monkeypatch.setattr(tool, "check_disambiguation", lambda cols, *a, **k: (False, []))
     monkeypatch.setattr(tool, "_describe_search_strategy", lambda *a, **k: "desc")
+
+    # Mock granule validation to return collections with granule counts
+    def mock_validate_granules(collections, *_args, **_kwargs):
+        for col in collections:
+            col.granule_count = 100
+        return collections
+
+    monkeypatch.setattr(tool, "validate_granule_availability", mock_validate_granules)
 
     query = DiscoverDataInput(query="test collection")
     output = tool.discover_data(query)
@@ -631,6 +662,14 @@ def test_end_to_end_disambiguation_with_user_refinement(monkeypatch):
     )
 
     monkeypatch.setattr(tool, "_describe_search_strategy", lambda *a, **k: "Multi-entity search")
+
+    # Mock granule validation to return collections with granule counts
+    def mock_validate_granules(collections, *_args, **_kwargs):
+        for col in collections:
+            col.granule_count = 100
+        return collections
+
+    monkeypatch.setattr(tool, "validate_granule_availability", mock_validate_granules)
 
     # === INITIAL QUERY (NO REFINEMENT) ===
     initial_query = DiscoverDataInput(query="I need land cover data")

--- a/tests/tools/discover_data/test_tool.py
+++ b/tests/tools/discover_data/test_tool.py
@@ -234,7 +234,6 @@ def test_discover_data_disambiguation_path(monkeypatch):
     monkeypatch.setattr(tool, "should_expand_query", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(tool, "check_disambiguation", lambda cols: (False, []))
 
-    # Mock granule validation to return collections with granule counts
     def mock_validate_granules(collections, *_args, **_kwargs):
         for col in collections:
             col.granule_count = 100
@@ -313,7 +312,6 @@ def test_discover_data_with_disambiguation_questions(monkeypatch):
     ]
     monkeypatch.setattr(tool, "check_disambiguation", lambda cols: (True, disamb_questions))
 
-    # Mock granule validation to return collections with granule counts
     def mock_validate_granules(collections, *_args, **_kwargs):
         for col in collections:
             col.granule_count = 100
@@ -440,7 +438,6 @@ def test_discover_data_with_langfuse(monkeypatch):
     monkeypatch.setattr(tool, "check_disambiguation", lambda cols, *a, **k: (False, []))
     monkeypatch.setattr(tool, "_describe_search_strategy", lambda *a, **k: "desc")
 
-    # Mock granule validation to return collections with granule counts
     def mock_validate_granules(collections, *_args, **_kwargs):
         for col in collections:
             col.granule_count = 100
@@ -663,7 +660,6 @@ def test_end_to_end_disambiguation_with_user_refinement(monkeypatch):
 
     monkeypatch.setattr(tool, "_describe_search_strategy", lambda *a, **k: "Multi-entity search")
 
-    # Mock granule validation to return collections with granule counts
     def mock_validate_granules(collections, *_args, **_kwargs):
         for col in collections:
             col.granule_count = 100
@@ -812,7 +808,6 @@ def test_discover_data_with_granule_validation(monkeypatch):
 
     # Mock validate_granule_availability to return only C1 (C2 filtered out)
     def mock_validate(cols, _temporal, _spatial, _wkt):
-        # Only C1 has granules
         return [c for c in cols if c.concept_id == "C1"]
 
     monkeypatch.setattr(tool, "validate_granule_availability", mock_validate)
@@ -820,7 +815,6 @@ def test_discover_data_with_granule_validation(monkeypatch):
     query = DiscoverDataInput(query="ocean data")
     output = tool.discover_data(query)
 
-    # Should return only one collection
     assert output["status"] == "collections_found"
     assert len(output["collections"]) == 1
     assert output["collections"][0]["concept_id"] == "C1"
@@ -860,12 +854,10 @@ def test_discover_data_all_filtered_by_granule_validation(monkeypatch):
     monkeypatch.setattr(tool, "check_disambiguation", lambda cols: (False, []))
     monkeypatch.setattr(tool, "filter_by_user_refinements", lambda cols, refs: cols)
 
-    # Mock validate_granule_availability to return empty list (all filtered)
     monkeypatch.setattr(tool, "validate_granule_availability", lambda *args: [])
 
     query = DiscoverDataInput(query="ocean data")
     output = tool.discover_data(query)
 
-    # Should return NO_GRANULES_IN_CONSTRAINTS status
     assert output["status"] == "no_granules_in_constraints"
     assert not output["collections"]

--- a/tests/tools/discover_data/test_tool.py
+++ b/tests/tools/discover_data/test_tool.py
@@ -340,7 +340,7 @@ def test_determine_status_variants():
     indirect = _make_collection("C2", match_type="via_variable")
 
     assert (
-        tool._determine_status([], [], [], all_filtered_by_granule_validation=True)
+        tool._determine_status([], False, [], all_filtered_by_granule_validation=True)
         == tool.DiscoveryStatus.NO_GRANULES_IN_CONSTRAINTS
     )
     assert (
@@ -348,7 +348,7 @@ def test_determine_status_variants():
         == tool.DiscoveryStatus.NO_GRANULES_IN_CONSTRAINTS
     )
     assert (
-        tool._determine_status([], [], [], all_filtered_by_granule_validation=False)
+        tool._determine_status([], False, [], all_filtered_by_granule_validation=False)
         == tool.DiscoveryStatus.NO_RESULTS
     )
     assert (

--- a/tests/tools/discover_data/utils/test_granule_availability.py
+++ b/tests/tools/discover_data/utils/test_granule_availability.py
@@ -171,6 +171,29 @@ class TestGetCacheTTL:
 class TestValidateGranuleAvailability:
     """Tests for validate_granule_availability function."""
 
+    def test_skips_validation_without_constraints(self, monkeypatch):
+        """Test that validation is skipped when no spatial or temporal constraints exist."""
+        collections = [
+            CollectionMatch(
+                concept_id="C1234-PROVIDER",
+                title="Test collection",
+                similarity_score=0.9,
+                match_type="direct",
+            )
+        ]
+
+        mock_count = Mock()
+        monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
+
+        # Call without constraints
+        result = granule_availability.validate_granule_availability(collections, None, None, None)
+
+        # Should return all collections unchanged
+        assert len(result) == 1
+        assert result[0].concept_id == "C1234-PROVIDER"
+        # Should not have called count_granules
+        mock_count.assert_not_called()
+
     def test_filters_collections_with_zero_granules(self, monkeypatch):
         """Test that collections with zero granules are filtered out."""
         collections = [
@@ -196,7 +219,9 @@ class TestValidateGranuleAvailability:
         mock_count = Mock(side_effect=[(100, 10), (0, 5)])
         monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
 
-        result = granule_availability.validate_granule_availability(collections, None, None, None)
+        result = granule_availability.validate_granule_availability(
+            collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
+        )
 
         assert len(result) == 1
         assert result[0].concept_id == "C1234-PROVIDER"
@@ -217,7 +242,9 @@ class TestValidateGranuleAvailability:
         mock_cache.get.return_value = '{"count": 50, "timestamp": 1234567890}'
         monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
 
-        result = granule_availability.validate_granule_availability(collections, None, None, None)
+        result = granule_availability.validate_granule_availability(
+            collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
+        )
 
         assert len(result) == 1
         assert result[0].granule_count == 50
@@ -249,7 +276,9 @@ class TestValidateGranuleAvailability:
         mock_count = Mock(return_value=(100, 10))
         monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
 
-        granule_availability.validate_granule_availability(collections, None, None, None)
+        granule_availability.validate_granule_availability(
+            collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
+        )
 
         # Check that cache.set was called with correct TTLs
         set_calls = mock_cache.set.call_args_list
@@ -284,7 +313,9 @@ class TestValidateGranuleAvailability:
         mock_count = Mock(side_effect=[(100, 10), CMRError("Failed")])
         monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
 
-        result = granule_availability.validate_granule_availability(collections, None, None, None)
+        result = granule_availability.validate_granule_availability(
+            collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
+        )
 
         # Should return the one that succeeded
         assert len(result) == 1
@@ -309,7 +340,9 @@ class TestValidateGranuleAvailability:
         mock_count = Mock(return_value=(100, 10))
         monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
 
-        result = granule_availability.validate_granule_availability(collections, None, None, None)
+        result = granule_availability.validate_granule_availability(
+            collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
+        )
 
         # All should succeed
         assert len(result) == 10

--- a/tests/tools/discover_data/utils/test_granule_availability.py
+++ b/tests/tools/discover_data/utils/test_granule_availability.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import pytest
 
 from tools.discover_data.utils import granule_availability
+from tools.discover_data.utils.granule_availability import GranuleValidationError
 from tools.models.output_model import CollectionMatch
 from util.cmr.client import CMRError, CMRSearchResponse
 
@@ -383,8 +384,8 @@ class TestValidateGranuleAvailability:
         # 900s for ongoing, 86400s for completed
         assert actual_ttls == {900, 86400}
 
-    def test_handles_validation_failures_gracefully(self, monkeypatch):
-        """Test that validation failures don't crash the entire process."""
+    def test_any_failure_raises_granule_validation_error(self, monkeypatch):
+        """Test that any CMR failure raises GranuleValidationError instead of returning partial results."""
         collections = [
             CollectionMatch(
                 concept_id="C1234-PROVIDER",
@@ -411,20 +412,17 @@ class TestValidateGranuleAvailability:
 
         monkeypatch.setattr(granule_availability, "_count_granules", _count_fail)
 
-        result = granule_availability.validate_granule_availability(
-            collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
-        )
+        with pytest.raises(GranuleValidationError):
+            granule_availability.validate_granule_availability(
+                collections,
+                datetime(2023, 1, 1, tzinfo=UTC),
+                datetime(2023, 12, 31, tzinfo=UTC),
+                None,
+            )
 
-        # Failed collections are kept (granule_count=None) rather than silently dropped;
-        # both collections should be present in the result.
-        assert len(result) == 2
-        result_by_id = {c.concept_id: c for c in result}
-        assert result_by_id["C1234-PROVIDER"].granule_count == 100
-        assert result_by_id["C5678-PROVIDER"].granule_count is None
-
-    def test_partial_failures_preserve_remaining_collections(self, monkeypatch):
-        """Test that a CMR failure for one collection does not affect others; all collections
-        are returned with successful ones keeping their counts and failed ones receiving None."""
+    def test_partial_failures_raise_granule_validation_error(self, monkeypatch):
+        """Test that a CMR failure for one collection raises GranuleValidationError
+        even when the other collections succeed."""
         collections = [
             CollectionMatch(
                 concept_id="C1234-PROVIDER",
@@ -457,16 +455,16 @@ class TestValidateGranuleAvailability:
 
         monkeypatch.setattr(granule_availability, "_count_granules", _count_two_pass)
 
-        result = granule_availability.validate_granule_availability(
-            collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
-        )
+        with pytest.raises(GranuleValidationError):
+            granule_availability.validate_granule_availability(
+                collections,
+                datetime(2023, 1, 1, tzinfo=UTC),
+                datetime(2023, 12, 31, tzinfo=UTC),
+                None,
+            )
 
-        assert len(result) == 3
-        none_count = sum(1 for c in result if c.granule_count is None)
-        assert none_count == 1  # exactly one failure, not inflated by iteration count
-
-    def test_failed_collections_preserved_not_dropped(self, monkeypatch):
-        """Test that collections with None granule_count (failures) are kept, not filtered."""
+    def test_single_failure_raises_granule_validation_error(self, monkeypatch):
+        """Test that even a single CMR failure raises GranuleValidationError."""
         collections = [
             CollectionMatch(
                 concept_id="C1234-PROVIDER",
@@ -483,15 +481,16 @@ class TestValidateGranuleAvailability:
         mock_count = Mock(side_effect=CMRError("Network error"))
         monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
 
-        result = granule_availability.validate_granule_availability(
-            collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
-        )
-
-        assert len(result) == 1
-        assert result[0].granule_count is None
+        with pytest.raises(GranuleValidationError):
+            granule_availability.validate_granule_availability(
+                collections,
+                datetime(2023, 1, 1, tzinfo=UTC),
+                datetime(2023, 12, 31, tzinfo=UTC),
+                None,
+            )
 
     def test_zero_granule_collections_excluded(self, monkeypatch):
-        """Test that collections with exactly 0 granules are excluded, but None (failures) are not."""
+        """Test that collections with exactly 0 granules are excluded from results."""
         collections = [
             CollectionMatch(
                 concept_id="C1111-PROVIDER",
@@ -505,24 +504,16 @@ class TestValidateGranuleAvailability:
                 similarity_score=0.8,
                 match_type="direct",
             ),
-            CollectionMatch(
-                concept_id="C3333-PROVIDER",
-                title="Failed validation",
-                similarity_score=0.7,
-                match_type="direct",
-            ),
         ]
 
         mock_cache = Mock()
         mock_cache.get.return_value = None
         monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
 
-        def _count_mixed(collection_concept_id, *_):
-            if collection_concept_id == "C3333-PROVIDER":
-                raise CMRError("Error")
-            return {"C1111-PROVIDER": (42, 5), "C2222-PROVIDER": (0, 5)}[collection_concept_id]
-
-        monkeypatch.setattr(granule_availability, "_count_granules", _count_mixed)
+        mock_count = Mock(
+            side_effect=lambda cid, *_: {"C1111-PROVIDER": (42, 5), "C2222-PROVIDER": (0, 5)}[cid]
+        )
+        monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
 
         result = granule_availability.validate_granule_availability(
             collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
@@ -531,7 +522,6 @@ class TestValidateGranuleAvailability:
         result_ids = {c.concept_id for c in result}
         assert "C1111-PROVIDER" in result_ids  # has granules: kept
         assert "C2222-PROVIDER" not in result_ids  # zero granules: dropped
-        assert "C3333-PROVIDER" in result_ids  # failure (None): kept
 
     def test_parallel_validation(self, monkeypatch):
         """Test that multiple collections are validated in parallel."""

--- a/tests/tools/discover_data/utils/test_granule_availability.py
+++ b/tests/tools/discover_data/utils/test_granule_availability.py
@@ -66,6 +66,58 @@ class TestCountGranules:
         # Should format with Z suffix (not +00:00)
         assert params["temporal"] == "2023-01-01T00:00:00Z,2023-12-31T00:00:00Z"
 
+    def test_count_granules_with_start_only_temporal(self, monkeypatch):
+        """Test that only temporal_start produces an open-ended end range."""
+        mock_response = CMRSearchResponse(
+            items=[],
+            total_hits=80,
+            took_ms=20,
+            search_after=None,
+            page_size=0,
+        )
+        start = datetime(2020, 6, 1, tzinfo=UTC)
+
+        mock_search = Mock(return_value=iter([mock_response]))
+        monkeypatch.setattr(granule_availability, "search_cmr", mock_search)
+
+        hits, _ = granule_availability._count_granules(
+            "C1234-PROVIDER",
+            temporal_start=start,
+        )
+
+        assert hits == 80
+        call_args = mock_search.call_args
+        params = call_args[1]["search_params"]
+        assert "temporal" in params
+        # Start-only: comma present with empty end
+        assert params["temporal"] == "2020-06-01T00:00:00Z,"
+
+    def test_count_granules_with_end_only_temporal(self, monkeypatch):
+        """Test that only temporal_end produces an open-ended start range."""
+        mock_response = CMRSearchResponse(
+            items=[],
+            total_hits=60,
+            took_ms=15,
+            search_after=None,
+            page_size=0,
+        )
+        end = datetime(2021, 3, 31, tzinfo=UTC)
+
+        mock_search = Mock(return_value=iter([mock_response]))
+        monkeypatch.setattr(granule_availability, "search_cmr", mock_search)
+
+        hits, _ = granule_availability._count_granules(
+            "C1234-PROVIDER",
+            temporal_end=end,
+        )
+
+        assert hits == 60
+        call_args = mock_search.call_args
+        params = call_args[1]["search_params"]
+        assert "temporal" in params
+        # End-only: comma present with empty start
+        assert params["temporal"] == ",2021-03-31T00:00:00Z"
+
     def test_count_granules_with_spatial_constraint(self, monkeypatch):
         """Test counting granules with spatial constraints."""
         mock_response = CMRSearchResponse(
@@ -88,7 +140,6 @@ class TestCountGranules:
         assert hits == 25
         assert took == 45
         call_args = mock_search.call_args
-        # Should use POST method with files when spatial constraint provided
         assert call_args[1]["method"] == "POST"
         assert call_args[1]["files"] is not None
 
@@ -185,14 +236,37 @@ class TestValidateGranuleAvailability:
         mock_count = Mock()
         monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
 
-        # Call without constraints
         result = granule_availability.validate_granule_availability(collections, None, None, None)
 
-        # Should return all collections unchanged
         assert len(result) == 1
         assert result[0].concept_id == "C1234-PROVIDER"
-        # Should not have called count_granules
         mock_count.assert_not_called()
+
+    def test_skips_validation_only_when_no_temporal_and_no_spatial(self, monkeypatch):
+        """Test that validation is only skipped when BOTH temporal bounds AND spatial are absent."""
+        collections = [
+            CollectionMatch(
+                concept_id="C1234-PROVIDER",
+                title="Test collection",
+                similarity_score=0.9,
+                match_type="direct",
+            )
+        ]
+
+        mock_cache = Mock()
+        mock_cache.get.return_value = None
+        monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
+
+        mock_count = Mock(return_value=(10, 5))
+        monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
+
+        # Only temporal_end provided (no temporal_start, no spatial)
+        result = granule_availability.validate_granule_availability(
+            collections, None, datetime(2023, 12, 31, tzinfo=UTC), None
+        )
+
+        mock_count.assert_called_once()
+        assert result[0].granule_count == 10
 
     def test_filters_collections_with_zero_granules(self, monkeypatch):
         """Test that collections with zero granules are filtered out."""
@@ -215,9 +289,10 @@ class TestValidateGranuleAvailability:
         mock_cache.get.return_value = None
         monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
 
-        # First collection has granules, second doesn't
-        mock_count = Mock(side_effect=[(100, 10), (0, 5)])
-        monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
+        def _count_zero(collection_concept_id, *_):
+            return {"C1234-PROVIDER": (100, 10), "C5678-PROVIDER": (0, 5)}[collection_concept_id]
+
+        monkeypatch.setattr(granule_availability, "_count_granules", _count_zero)
 
         result = granule_availability.validate_granule_availability(
             collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
@@ -250,6 +325,27 @@ class TestValidateGranuleAvailability:
         assert result[0].granule_count == 50
         mock_cache.get.assert_called_once()
 
+    def test_cached_zero_granule_collection_excluded(self, monkeypatch):
+        """Test that a cached granule count of 0 still excludes the collection."""
+        collections = [
+            CollectionMatch(
+                concept_id="C1234-PROVIDER",
+                title="Zero granules (cached)",
+                similarity_score=0.9,
+                match_type="direct",
+            ),
+        ]
+
+        mock_cache = Mock()
+        mock_cache.get.return_value = '{"count": 0, "timestamp": 1234567890}'
+        monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
+
+        result = granule_availability.validate_granule_availability(
+            collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
+        )
+
+        assert len(result) == 0
+
     def test_caches_results_with_correct_ttl(self, monkeypatch):
         """Test that results are cached with appropriate TTL based on is_ongoing."""
         collections = [
@@ -280,13 +376,12 @@ class TestValidateGranuleAvailability:
             collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
         )
 
-        # Check that cache.set was called with correct TTLs
+        # Use a set — thread completion order via as_completed is non-deterministic
         set_calls = mock_cache.set.call_args_list
         assert len(set_calls) == 2
-        # Ongoing collection should have 900s TTL
-        assert set_calls[0][1]["ttl"] == 900
-        # Completed collection should have 86400s TTL
-        assert set_calls[1][1]["ttl"] == 86400
+        actual_ttls = {call[1]["ttl"] for call in set_calls}
+        # 900s for ongoing, 86400s for completed
+        assert actual_ttls == {900, 86400}
 
     def test_handles_validation_failures_gracefully(self, monkeypatch):
         """Test that validation failures don't crash the entire process."""
@@ -309,17 +404,134 @@ class TestValidateGranuleAvailability:
         mock_cache.get.return_value = None
         monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
 
-        # First succeeds, second fails
-        mock_count = Mock(side_effect=[(100, 10), CMRError("Failed")])
+        def _count_fail(collection_concept_id, *_):
+            if collection_concept_id == "C5678-PROVIDER":
+                raise CMRError("Failed")
+            return (100, 10)
+
+        monkeypatch.setattr(granule_availability, "_count_granules", _count_fail)
+
+        result = granule_availability.validate_granule_availability(
+            collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
+        )
+
+        # Failed collections are kept (granule_count=None) rather than silently dropped;
+        # both collections should be present in the result.
+        assert len(result) == 2
+        result_by_id = {c.concept_id: c for c in result}
+        assert result_by_id["C1234-PROVIDER"].granule_count == 100
+        assert result_by_id["C5678-PROVIDER"].granule_count is None
+
+    def test_partial_failures_preserve_remaining_collections(self, monkeypatch):
+        """Test that a CMR failure for one collection does not affect others; all collections
+        are returned with successful ones keeping their counts and failed ones receiving None."""
+        collections = [
+            CollectionMatch(
+                concept_id="C1234-PROVIDER",
+                title="Good collection",
+                similarity_score=0.9,
+                match_type="direct",
+            ),
+            CollectionMatch(
+                concept_id="C5678-PROVIDER",
+                title="Also good collection",
+                similarity_score=0.8,
+                match_type="direct",
+            ),
+            CollectionMatch(
+                concept_id="C9999-PROVIDER",
+                title="Error collection",
+                similarity_score=0.7,
+                match_type="direct",
+            ),
+        ]
+
+        mock_cache = Mock()
+        mock_cache.get.return_value = None
+        monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
+
+        def _count_two_pass(collection_concept_id, *_):
+            if collection_concept_id == "C9999-PROVIDER":
+                raise CMRError("Failed")
+            return {"C1234-PROVIDER": (100, 10), "C5678-PROVIDER": (50, 5)}[collection_concept_id]
+
+        monkeypatch.setattr(granule_availability, "_count_granules", _count_two_pass)
+
+        result = granule_availability.validate_granule_availability(
+            collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
+        )
+
+        assert len(result) == 3
+        none_count = sum(1 for c in result if c.granule_count is None)
+        assert none_count == 1  # exactly one failure, not inflated by iteration count
+
+    def test_failed_collections_preserved_not_dropped(self, monkeypatch):
+        """Test that collections with None granule_count (failures) are kept, not filtered."""
+        collections = [
+            CollectionMatch(
+                concept_id="C1234-PROVIDER",
+                title="Failing collection",
+                similarity_score=0.9,
+                match_type="direct",
+            ),
+        ]
+
+        mock_cache = Mock()
+        mock_cache.get.return_value = None
+        monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
+
+        mock_count = Mock(side_effect=CMRError("Network error"))
         monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
 
         result = granule_availability.validate_granule_availability(
             collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
         )
 
-        # Should return the one that succeeded
         assert len(result) == 1
-        assert result[0].concept_id == "C1234-PROVIDER"
+        assert result[0].granule_count is None
+
+    def test_zero_granule_collections_excluded(self, monkeypatch):
+        """Test that collections with exactly 0 granules are excluded, but None (failures) are not."""
+        collections = [
+            CollectionMatch(
+                concept_id="C1111-PROVIDER",
+                title="Has granules",
+                similarity_score=0.9,
+                match_type="direct",
+            ),
+            CollectionMatch(
+                concept_id="C2222-PROVIDER",
+                title="Zero granules",
+                similarity_score=0.8,
+                match_type="direct",
+            ),
+            CollectionMatch(
+                concept_id="C3333-PROVIDER",
+                title="Failed validation",
+                similarity_score=0.7,
+                match_type="direct",
+            ),
+        ]
+
+        mock_cache = Mock()
+        mock_cache.get.return_value = None
+        monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
+
+        def _count_mixed(collection_concept_id, *_):
+            if collection_concept_id == "C3333-PROVIDER":
+                raise CMRError("Error")
+            return {"C1111-PROVIDER": (42, 5), "C2222-PROVIDER": (0, 5)}[collection_concept_id]
+
+        monkeypatch.setattr(granule_availability, "_count_granules", _count_mixed)
+
+        result = granule_availability.validate_granule_availability(
+            collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
+        )
+
+        result_ids = {c.concept_id for c in result}
+        assert "C1111-PROVIDER" in result_ids  # has granules: kept
+        assert "C2222-PROVIDER" not in result_ids  # zero granules: dropped
+        assert "C3333-PROVIDER" in result_ids  # failure (None): kept
 
     def test_parallel_validation(self, monkeypatch):
         """Test that multiple collections are validated in parallel."""
@@ -344,7 +556,5 @@ class TestValidateGranuleAvailability:
             collections, datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 12, 31, tzinfo=UTC), None
         )
 
-        # All should succeed
         assert len(result) == 10
-        # Should have been called for each collection
         assert mock_count.call_count == 10

--- a/tests/tools/discover_data/utils/test_granule_availability.py
+++ b/tests/tools/discover_data/utils/test_granule_availability.py
@@ -1,0 +1,317 @@
+"""Tests for granule availability validation."""
+
+from datetime import UTC, datetime
+from unittest.mock import Mock
+
+import pytest
+
+from tools.discover_data.utils import granule_availability
+from tools.models.output_model import CollectionMatch
+from util.cmr.client import CMRError, CMRSearchResponse
+
+
+class TestCountGranules:
+    """Tests for _count_granules function."""
+
+    def test_count_granules_no_constraints(self, monkeypatch):
+        """Test counting granules without temporal/spatial constraints."""
+        mock_response = CMRSearchResponse(
+            items=[],
+            total_hits=150,
+            took_ms=25,
+            search_after=None,
+            page_size=0,
+        )
+        mock_search = Mock(return_value=iter([mock_response]))
+        monkeypatch.setattr(granule_availability, "search_cmr", mock_search)
+
+        hits, took = granule_availability._count_granules("C1234-PROVIDER")
+
+        assert hits == 150
+        assert took == 25
+        mock_search.assert_called_once()
+        call_args = mock_search.call_args
+        assert call_args[1]["concept_type"] == "granule"
+        assert call_args[1]["search_params"]["collection_concept_id"] == "C1234-PROVIDER"
+        assert not call_args[1]["page_size"]
+        assert call_args[1]["method"] == "POST"
+        assert call_args[1]["files"] is None
+
+    def test_count_granules_with_temporal_constraint(self, monkeypatch):
+        """Test counting granules with temporal constraints."""
+        mock_response = CMRSearchResponse(
+            items=[],
+            total_hits=50,
+            took_ms=30,
+            search_after=None,
+            page_size=0,
+        )
+        start = datetime(2023, 1, 1, tzinfo=UTC)
+        end = datetime(2023, 12, 31, tzinfo=UTC)
+
+        mock_search = Mock(return_value=iter([mock_response]))
+        monkeypatch.setattr(granule_availability, "search_cmr", mock_search)
+
+        hits, took = granule_availability._count_granules(
+            "C1234-PROVIDER",
+            temporal_start=start,
+            temporal_end=end,
+        )
+
+        assert hits == 50
+        assert took == 30
+        call_args = mock_search.call_args
+        params = call_args[1]["search_params"]
+        assert "temporal" in params
+        # Should format with Z suffix (not +00:00)
+        assert params["temporal"] == "2023-01-01T00:00:00Z,2023-12-31T00:00:00Z"
+
+    def test_count_granules_with_spatial_constraint(self, monkeypatch):
+        """Test counting granules with spatial constraints."""
+        mock_response = CMRSearchResponse(
+            items=[],
+            total_hits=25,
+            took_ms=45,
+            search_after=None,
+            page_size=0,
+        )
+        wkt = "POLYGON((-180 -90,-180 90,180 90,180 -90,-180 -90))"
+
+        mock_search = Mock(return_value=iter([mock_response]))
+        monkeypatch.setattr(granule_availability, "search_cmr", mock_search)
+
+        hits, took = granule_availability._count_granules(
+            "C1234-PROVIDER",
+            spatial_wkt=wkt,
+        )
+
+        assert hits == 25
+        assert took == 45
+        call_args = mock_search.call_args
+        # Should use POST method with files when spatial constraint provided
+        assert call_args[1]["method"] == "POST"
+        assert call_args[1]["files"] is not None
+
+    def test_count_granules_cmr_error(self, monkeypatch):
+        """Test that CMR errors are propagated."""
+        mock_search = Mock(side_effect=CMRError("CMR request failed"))
+        monkeypatch.setattr(granule_availability, "search_cmr", mock_search)
+
+        with pytest.raises(CMRError, match="CMR request failed"):
+            granule_availability._count_granules("C1234-PROVIDER")
+
+    def test_count_granules_no_response(self, monkeypatch):
+        """Test handling of empty response from CMR."""
+        mock_search = Mock(return_value=iter([]))
+        monkeypatch.setattr(granule_availability, "search_cmr", mock_search)
+
+        hits, took = granule_availability._count_granules("C1234-PROVIDER")
+
+        assert not hits
+        assert not took
+
+
+class TestBuildCacheKey:
+    """Tests for _build_cache_key function."""
+
+    def test_cache_key_with_all_constraints(self):
+        """Test cache key generation with all constraints."""
+        start = datetime(2023, 1, 1, tzinfo=UTC)
+        end = datetime(2023, 12, 31, tzinfo=UTC)
+        wkt = "POLYGON((0 0,1 0,1 1,0 1,0 0))"
+
+        key = granule_availability._build_cache_key("C1234-PROVIDER", start, end, wkt)
+
+        assert key.startswith("granule_count:C1234-PROVIDER:")
+        assert len(key.split(":")) == 3  # prefix:concept_id:hash
+
+    def test_cache_key_without_constraints(self):
+        """Test cache key generation without constraints."""
+        key = granule_availability._build_cache_key("C1234-PROVIDER", None, None, None)
+
+        assert key.startswith("granule_count:C1234-PROVIDER:")
+
+    def test_cache_key_deterministic(self):
+        """Test that same inputs produce same cache key."""
+        start = datetime(2023, 1, 1, tzinfo=UTC)
+        end = datetime(2023, 12, 31, tzinfo=UTC)
+        wkt = "POLYGON((0 0,1 0,1 1,0 1,0 0))"
+
+        key1 = granule_availability._build_cache_key("C1234-PROVIDER", start, end, wkt)
+        key2 = granule_availability._build_cache_key("C1234-PROVIDER", start, end, wkt)
+
+        assert key1 == key2
+
+    def test_cache_key_different_for_different_constraints(self):
+        """Test that different constraints produce different cache keys."""
+        start1 = datetime(2023, 1, 1, tzinfo=UTC)
+        start2 = datetime(2024, 1, 1, tzinfo=UTC)
+        end = datetime(2023, 12, 31, tzinfo=UTC)
+
+        key1 = granule_availability._build_cache_key("C1234-PROVIDER", start1, end, None)
+        key2 = granule_availability._build_cache_key("C1234-PROVIDER", start2, end, None)
+
+        assert key1 != key2
+
+
+class TestGetCacheTTL:
+    """Tests for _get_cache_ttl function."""
+
+    def test_ongoing_collection_ttl(self):
+        """Test that ongoing collections get short TTL."""
+        ttl = granule_availability._get_cache_ttl(is_ongoing=True)
+        assert ttl == 900  # 15 minutes
+
+    def test_completed_collection_ttl(self):
+        """Test that completed collections get long TTL."""
+        ttl = granule_availability._get_cache_ttl(is_ongoing=False)
+        assert ttl == 86400  # 24 hours
+
+
+class TestValidateGranuleAvailability:
+    """Tests for validate_granule_availability function."""
+
+    def test_filters_collections_with_zero_granules(self, monkeypatch):
+        """Test that collections with zero granules are filtered out."""
+        collections = [
+            CollectionMatch(
+                concept_id="C1234-PROVIDER",
+                title="Collection with granules",
+                similarity_score=0.9,
+                match_type="direct",
+            ),
+            CollectionMatch(
+                concept_id="C5678-PROVIDER",
+                title="Collection without granules",
+                similarity_score=0.8,
+                match_type="direct",
+            ),
+        ]
+
+        mock_cache = Mock()
+        mock_cache.get.return_value = None
+        monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
+
+        # First collection has granules, second doesn't
+        mock_count = Mock(side_effect=[(100, 10), (0, 5)])
+        monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
+
+        result = granule_availability.validate_granule_availability(collections, None, None, None)
+
+        assert len(result) == 1
+        assert result[0].concept_id == "C1234-PROVIDER"
+        assert result[0].granule_count == 100
+
+    def test_uses_cache_when_available(self, monkeypatch):
+        """Test that cached results are used when available."""
+        collections = [
+            CollectionMatch(
+                concept_id="C1234-PROVIDER",
+                title="Cached collection",
+                similarity_score=0.9,
+                match_type="direct",
+            )
+        ]
+
+        mock_cache = Mock()
+        mock_cache.get.return_value = '{"count": 50, "timestamp": 1234567890}'
+        monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
+
+        result = granule_availability.validate_granule_availability(collections, None, None, None)
+
+        assert len(result) == 1
+        assert result[0].granule_count == 50
+        mock_cache.get.assert_called_once()
+
+    def test_caches_results_with_correct_ttl(self, monkeypatch):
+        """Test that results are cached with appropriate TTL based on is_ongoing."""
+        collections = [
+            CollectionMatch(
+                concept_id="C1234-PROVIDER",
+                title="Ongoing collection",
+                similarity_score=0.9,
+                match_type="direct",
+                is_ongoing=True,
+            ),
+            CollectionMatch(
+                concept_id="C5678-PROVIDER",
+                title="Completed collection",
+                similarity_score=0.8,
+                match_type="direct",
+                is_ongoing=False,
+            ),
+        ]
+
+        mock_cache = Mock()
+        mock_cache.get.return_value = None
+        monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
+
+        mock_count = Mock(return_value=(100, 10))
+        monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
+
+        granule_availability.validate_granule_availability(collections, None, None, None)
+
+        # Check that cache.set was called with correct TTLs
+        set_calls = mock_cache.set.call_args_list
+        assert len(set_calls) == 2
+        # Ongoing collection should have 900s TTL
+        assert set_calls[0][1]["ttl"] == 900
+        # Completed collection should have 86400s TTL
+        assert set_calls[1][1]["ttl"] == 86400
+
+    def test_handles_validation_failures_gracefully(self, monkeypatch):
+        """Test that validation failures don't crash the entire process."""
+        collections = [
+            CollectionMatch(
+                concept_id="C1234-PROVIDER",
+                title="Good collection",
+                similarity_score=0.9,
+                match_type="direct",
+            ),
+            CollectionMatch(
+                concept_id="C5678-PROVIDER",
+                title="Error collection",
+                similarity_score=0.8,
+                match_type="direct",
+            ),
+        ]
+
+        mock_cache = Mock()
+        mock_cache.get.return_value = None
+        monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
+
+        # First succeeds, second fails
+        mock_count = Mock(side_effect=[(100, 10), CMRError("Failed")])
+        monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
+
+        result = granule_availability.validate_granule_availability(collections, None, None, None)
+
+        # Should return the one that succeeded
+        assert len(result) == 1
+        assert result[0].concept_id == "C1234-PROVIDER"
+
+    def test_parallel_validation(self, monkeypatch):
+        """Test that multiple collections are validated in parallel."""
+        collections = [
+            CollectionMatch(
+                concept_id=f"C{i}-PROVIDER",
+                title=f"Collection {i}",
+                similarity_score=0.9,
+                match_type="direct",
+            )
+            for i in range(10)
+        ]
+
+        mock_cache = Mock()
+        mock_cache.get.return_value = None
+        monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
+
+        mock_count = Mock(return_value=(100, 10))
+        monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
+
+        result = granule_availability.validate_granule_availability(collections, None, None, None)
+
+        # All should succeed
+        assert len(result) == 10
+        # Should have been called for each collection
+        assert mock_count.call_count == 10

--- a/tests/tools/discover_data/utils/test_granule_availability.py
+++ b/tests/tools/discover_data/utils/test_granule_availability.py
@@ -314,7 +314,7 @@ class TestValidateGranuleAvailability:
         ]
 
         mock_cache = Mock()
-        mock_cache.get.return_value = '{"count": 50, "timestamp": 1234567890}'
+        mock_cache.get.return_value = {"count": 50, "timestamp": 1234567890}
         monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
 
         result = granule_availability.validate_granule_availability(
@@ -337,7 +337,7 @@ class TestValidateGranuleAvailability:
         ]
 
         mock_cache = Mock()
-        mock_cache.get.return_value = '{"count": 0, "timestamp": 1234567890}'
+        mock_cache.get.return_value = {"count": 0, "timestamp": 1234567890}
         monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
 
         result = granule_availability.validate_granule_availability(

--- a/tests/utils/cmr/test_client.py
+++ b/tests/utils/cmr/test_client.py
@@ -303,3 +303,54 @@ class TestSearchCmrPost:
 
         mock_post.assert_called_once()
         mock_get.assert_not_called()
+
+
+class TestClientIdHeader:
+    """Tests that the Client-Id header is sent on every request type."""
+
+    def test_fetch_concept_sends_client_id(self, monkeypatch):
+        """fetch_concept should include Client-Id in the request headers."""
+        mock_get = Mock(return_value=_make_response(json_data={}))
+        monkeypatch.setattr("util.cmr.client.requests.get", mock_get)
+        monkeypatch.setattr("util.cmr.client.CLIENT_ID", "eed-test-mcp")
+
+        fetch_concept("C1234-PROVIDER", "1")
+
+        sent_headers = mock_get.call_args[1]["headers"]
+        assert sent_headers["Client-Id"] == "eed-test-mcp"
+
+    def test_fetch_associations_sends_client_id(self, monkeypatch):
+        """fetch_associations should include Client-Id in the request headers."""
+        json_data = {"items": [{"meta": {"associations": {}}, "umm": {}}]}
+        mock_get = Mock(return_value=_make_response(json_data=json_data))
+        monkeypatch.setattr("util.cmr.client.requests.get", mock_get)
+        monkeypatch.setattr("util.cmr.client.CLIENT_ID", "eed-test-mcp")
+
+        fetch_associations("C1234-PROVIDER")
+
+        sent_headers = mock_get.call_args[1]["headers"]
+        assert sent_headers["Client-Id"] == "eed-test-mcp"
+
+    def test_search_cmr_get_sends_client_id(self, monkeypatch):
+        """search_cmr GET should include Client-Id in the request headers."""
+        items = [{"meta": {"concept-id": "C1-P"}, "umm": {}}]
+        mock_get = Mock(return_value=_make_response(json_data={"items": items}))
+        monkeypatch.setattr("util.cmr.client.requests.get", mock_get)
+        monkeypatch.setattr("util.cmr.client.CLIENT_ID", "eed-test-mcp")
+
+        list(search_cmr("collection", {}, page_size=1))
+
+        sent_headers = mock_get.call_args[1]["headers"]
+        assert sent_headers["Client-Id"] == "eed-test-mcp"
+
+    def test_search_cmr_post_sends_client_id(self, monkeypatch):
+        """search_cmr POST should include Client-Id in the request headers."""
+        items = [{"meta": {"concept-id": "C1-P"}, "umm": {}}]
+        mock_post = Mock(return_value=_make_response(json_data={"items": items}))
+        monkeypatch.setattr("util.cmr.client.requests.post", mock_post)
+        monkeypatch.setattr("util.cmr.client.CLIENT_ID", "eed-test-mcp")
+
+        list(search_cmr("granule", {}, page_size=1, method="POST"))
+
+        sent_headers = mock_post.call_args[1]["headers"]
+        assert sent_headers["Client-Id"] == "eed-test-mcp"

--- a/tests/utils/cmr/test_client.py
+++ b/tests/utils/cmr/test_client.py
@@ -1,0 +1,305 @@
+"""Tests for CMR API client."""
+
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from util.cmr.client import (
+    CMRError,
+    CMRSearchResponse,
+    fetch_associations,
+    fetch_concept,
+    search_cmr,
+)
+
+
+def _make_response(*, json_data=None, headers=None):
+    """Build a mock requests.Response with configurable attributes."""
+    response = Mock()
+    response.json.return_value = json_data or {}
+    response.headers = {
+        "CMR-Hits": "0",
+        "CMR-Took": "5",
+        **(headers or {}),
+    }
+    response.raise_for_status.return_value = None
+    return response
+
+
+class TestFetchConcept:
+    """Test fetch_concept function."""
+
+    def test_returns_concept_metadata(self, monkeypatch):
+        """Should return parsed JSON for a valid concept."""
+        expected = {"meta": {"concept-id": "C1234-PROVIDER"}, "umm": {}}
+        mock_get = Mock(return_value=_make_response(json_data=expected))
+        monkeypatch.setattr("util.cmr.client.requests.get", mock_get)
+
+        result = fetch_concept("C1234-PROVIDER", "1")
+
+        assert result == expected
+        mock_get.assert_called_once()
+        assert "C1234-PROVIDER/1.umm_json" in mock_get.call_args[0][0]
+
+    def test_raises_cmr_error_on_request_failure(self, monkeypatch):
+        """Should raise CMRError when the request fails."""
+        monkeypatch.setattr(
+            "util.cmr.client.requests.get",
+            Mock(side_effect=requests.ConnectionError("timeout")),
+        )
+
+        with pytest.raises(CMRError, match="Failed to fetch C1234-PROVIDER"):
+            fetch_concept("C1234-PROVIDER", "1")
+
+    def test_raises_cmr_error_on_http_error(self, monkeypatch):
+        """Should raise CMRError on non-2xx HTTP response."""
+        bad_response = _make_response()
+        bad_response.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
+        monkeypatch.setattr("util.cmr.client.requests.get", Mock(return_value=bad_response))
+
+        with pytest.raises(CMRError):
+            fetch_concept("C9999-MISSING", "1")
+
+
+class TestFetchAssociations:
+    """Test fetch_associations function."""
+
+    def test_returns_associations_for_collection(self, monkeypatch):
+        """Should return associations dict from collection metadata."""
+        associations = {"variables": ["V1-PROVIDER"], "citations": []}
+        json_data = {"items": [{"meta": {"associations": associations}, "umm": {}}]}
+        monkeypatch.setattr(
+            "util.cmr.client.requests.get",
+            Mock(return_value=_make_response(json_data=json_data)),
+        )
+
+        result = fetch_associations("C1234-PROVIDER")
+
+        assert result == associations
+
+    def test_returns_empty_dict_when_no_items(self, monkeypatch):
+        """Should return empty dict when collection not found."""
+        monkeypatch.setattr(
+            "util.cmr.client.requests.get",
+            Mock(return_value=_make_response(json_data={"items": []})),
+        )
+
+        result = fetch_associations("C9999-MISSING")
+
+        assert result == {}
+
+    def test_returns_empty_dict_on_request_failure(self, monkeypatch):
+        """Should return empty dict (not raise) when request fails."""
+        monkeypatch.setattr(
+            "util.cmr.client.requests.get",
+            Mock(side_effect=requests.ConnectionError("timeout")),
+        )
+
+        result = fetch_associations("C1234-PROVIDER")
+
+        assert result == {}
+
+    def test_returns_empty_dict_when_no_associations_key(self, monkeypatch):
+        """Should return empty dict when meta has no associations key."""
+        json_data = {"items": [{"meta": {}, "umm": {}}]}
+        monkeypatch.setattr(
+            "util.cmr.client.requests.get",
+            Mock(return_value=_make_response(json_data=json_data)),
+        )
+
+        result = fetch_associations("C1234-PROVIDER")
+
+        assert result == {}
+
+
+class TestSearchCmrGet:
+    """Test search_cmr with GET method (default)."""
+
+    def test_raises_on_unsupported_concept_type(self):
+        """Should raise CMRError for unknown concept types."""
+        with pytest.raises(CMRError, match="Unsupported concept_type"):
+            list(search_cmr("unknown_type", {}))
+
+    def test_yields_single_page_of_results(self, monkeypatch):
+        """Should yield one CMRSearchResponse for a single page of results."""
+        items = [{"meta": {"concept-id": "C1-P"}, "umm": {}}]
+        response = _make_response(
+            json_data={"items": items},
+            headers={"CMR-Hits": "1", "CMR-Took": "10"},
+        )
+        monkeypatch.setattr("util.cmr.client.requests.get", Mock(return_value=response))
+
+        pages = list(search_cmr("collection", {"keyword": "modis"}, page_size=10))
+
+        assert len(pages) == 1
+        assert isinstance(pages[0], CMRSearchResponse)
+        assert pages[0].items == items
+        assert pages[0].total_hits == 1
+        assert pages[0].took_ms == 10
+        assert pages[0].page_size == 1
+
+    def test_paginates_using_search_after(self, monkeypatch):
+        """Should follow search-after token until exhausted."""
+        page1_items = [{"meta": {"concept-id": "C1-P"}, "umm": {}}]
+        page2_items = [{"meta": {"concept-id": "C2-P"}, "umm": {}}]
+
+        page1 = _make_response(
+            json_data={"items": page1_items},
+            headers={"CMR-Hits": "2", "CMR-Took": "5", "CMR-Search-After": "token-abc"},
+        )
+        page2 = _make_response(
+            json_data={"items": page2_items},
+            headers={"CMR-Hits": "2", "CMR-Took": "4"},
+        )
+
+        mock_get = Mock(side_effect=[page1, page2])
+        monkeypatch.setattr("util.cmr.client.requests.get", mock_get)
+
+        pages = list(search_cmr("collection", {}, page_size=1))
+
+        assert len(pages) == 2
+        assert pages[0].items == page1_items
+        assert pages[1].items == page2_items
+        # Second request should carry the search-after header
+        second_call_headers = mock_get.call_args_list[1][1]["headers"]
+        assert second_call_headers["CMR-Search-After"] == "token-abc"
+
+    def test_stops_when_no_items_returned(self, monkeypatch):
+        """Should stop pagination when an empty items list is returned."""
+        response = _make_response(
+            json_data={"items": []},
+            headers={"CMR-Hits": "0", "CMR-Took": "2"},
+        )
+        monkeypatch.setattr("util.cmr.client.requests.get", Mock(return_value=response))
+
+        pages = list(search_cmr("collection", {}))
+
+        assert pages == []
+
+    def test_raises_cmr_error_on_request_failure(self, monkeypatch):
+        """Should raise CMRError when the HTTP request fails."""
+        monkeypatch.setattr(
+            "util.cmr.client.requests.get",
+            Mock(side_effect=requests.ConnectionError("refused")),
+        )
+
+        with pytest.raises(CMRError, match="CMR request failed"):
+            list(search_cmr("collection", {}))
+
+    def test_count_only_query_returns_single_page(self, monkeypatch):
+        """Should yield one page with empty items for page_size=0 count queries."""
+        response = _make_response(
+            json_data={"items": []},
+            headers={"CMR-Hits": "42", "CMR-Took": "3"},
+        )
+        monkeypatch.setattr("util.cmr.client.requests.get", Mock(return_value=response))
+
+        pages = list(search_cmr("granule", {"collection_concept_id": "C1-P"}, page_size=0))
+
+        assert len(pages) == 1
+        assert pages[0].total_hits == 42
+        assert pages[0].items == []
+        assert pages[0].page_size == 0
+
+
+class TestSearchCmrPost:
+    """Test search_cmr with POST method."""
+
+    def test_uses_post_when_method_is_post(self, monkeypatch):
+        """Should call requests.post instead of requests.get."""
+        items = [{"meta": {"concept-id": "C1-P"}, "umm": {}}]
+        response = _make_response(
+            json_data={"items": items},
+            headers={"CMR-Hits": "1", "CMR-Took": "8"},
+        )
+        mock_post = Mock(return_value=response)
+        mock_get = Mock()
+        monkeypatch.setattr("util.cmr.client.requests.post", mock_post)
+        monkeypatch.setattr("util.cmr.client.requests.get", mock_get)
+
+        pages = list(search_cmr("granule", {"collection_concept_id": "C1-P"}, method="POST"))
+
+        mock_post.assert_called_once()
+        mock_get.assert_not_called()
+        assert len(pages) == 1
+        assert pages[0].items == items
+
+    def test_passes_files_in_post_request(self, monkeypatch):
+        """Should forward the files dict to requests.post for spatial queries."""
+        response = _make_response(
+            json_data={"items": []},
+            headers={"CMR-Hits": "0", "CMR-Took": "5"},
+        )
+        mock_post = Mock(return_value=response)
+        monkeypatch.setattr("util.cmr.client.requests.post", mock_post)
+
+        shapefile = {"shapefile": ("shapefile", b"geojson-bytes", "application/geo+json")}
+        list(search_cmr("granule", {"page_size": 0}, method="POST", files=shapefile))
+
+        call_kwargs = mock_post.call_args[1]
+        assert call_kwargs["files"] == shapefile
+
+    def test_passes_params_as_data_in_post_request(self, monkeypatch):
+        """Should send search params as form data (not query string) in POST."""
+        response = _make_response(
+            json_data={"items": []},
+            headers={"CMR-Hits": "0", "CMR-Took": "3"},
+        )
+        mock_post = Mock(return_value=response)
+        monkeypatch.setattr("util.cmr.client.requests.post", mock_post)
+
+        params = {"collection_concept_id": "C1-P", "page_size": 0}
+        list(search_cmr("granule", params, page_size=0, method="POST"))
+
+        call_kwargs = mock_post.call_args[1]
+        assert "data" in call_kwargs
+        assert call_kwargs["data"]["collection_concept_id"] == "C1-P"
+
+    def test_count_only_post_returns_total_hits(self, monkeypatch):
+        """POST count-only query (page_size=0) should return correct hit count."""
+        response = _make_response(
+            json_data={"items": []},
+            headers={"CMR-Hits": "137", "CMR-Took": "6"},
+        )
+        monkeypatch.setattr("util.cmr.client.requests.post", Mock(return_value=response))
+
+        pages = list(
+            search_cmr(
+                "granule",
+                {"collection_concept_id": "C1-P"},
+                page_size=0,
+                method="POST",
+            )
+        )
+
+        assert len(pages) == 1
+        assert pages[0].total_hits == 137
+        assert pages[0].items == []
+
+    def test_raises_cmr_error_on_post_failure(self, monkeypatch):
+        """Should raise CMRError when the POST request fails."""
+        monkeypatch.setattr(
+            "util.cmr.client.requests.post",
+            Mock(side_effect=requests.ConnectionError("refused")),
+        )
+
+        with pytest.raises(CMRError, match="CMR request failed"):
+            list(search_cmr("granule", {}, method="POST"))
+
+    def test_method_matching_is_case_insensitive(self, monkeypatch):
+        """Should treat 'post' (lowercase) the same as 'POST'."""
+        items = [{"meta": {"concept-id": "C1-P"}, "umm": {}}]
+        response = _make_response(
+            json_data={"items": items},
+            headers={"CMR-Hits": "1", "CMR-Took": "4"},
+        )
+        mock_post = Mock(return_value=response)
+        mock_get = Mock()
+        monkeypatch.setattr("util.cmr.client.requests.post", mock_post)
+        monkeypatch.setattr("util.cmr.client.requests.get", mock_get)
+
+        list(search_cmr("granule", {}, method="post"))  # type: ignore[arg-type]
+
+        mock_post.assert_called_once()
+        mock_get.assert_not_called()

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -1,6 +1,7 @@
 """Tests for cache utility."""
 
 import json
+import os
 from unittest.mock import Mock, patch
 
 import pytest
@@ -63,6 +64,7 @@ class TestGetRedisCredentials:
 class TestRedisCacheInitialization:
     """Test RedisCache initialization and connection."""
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -92,12 +94,21 @@ class TestRedisCacheInitialization:
             # Verify connection test was performed
             mock_client.ping.assert_called_once()
 
-            # Verify success was logged
-            mock_logger.info.assert_called_once_with("Successfully connected to Redis")
+            # Verify success was logged (should have 2 info calls)
+            assert mock_logger.info.call_count == 2
+            assert (
+                mock_logger.info.call_args_list[0][0][0]
+                == "Using AWS Secrets Manager Redis configuration"
+            )
+            assert (
+                mock_logger.info.call_args_list[1][0][0]
+                == "Successfully connected to Redis via Secrets Manager"
+            )
 
             # Verify client is available
             assert client.client is not None
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -120,6 +131,7 @@ class TestRedisCacheInitialization:
             # Verify client is None
             assert client.client is None
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -138,19 +150,132 @@ class TestRedisCacheInitialization:
             # Verify client is None
             assert client.client is None
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", None)
     def test_no_connection_without_secret_id(self):
         """Test that Redis is disabled when REDIS_SECRET_ID is not set."""
         with patch("util.cache.logger") as mock_logger:
             client = RedisCache()
 
-            mock_logger.info.assert_called_once_with("REDIS_SECRET_ID not set, caching disabled")
+            mock_logger.info.assert_called_once_with(
+                "REDIS_SECRET_ID not set and no local Redis config found, caching disabled"
+            )
+            assert client.client is None
+
+    @patch.dict(os.environ, {"REDIS_HOST": "localhost"}, clear=False)
+    @patch("util.cache.redis.Redis")
+    def test_local_redis_successful_connection(self, mock_redis_class):
+        """Test successful connection to local Redis using REDIS_HOST."""
+        mock_client = Mock()
+        mock_redis_class.return_value = mock_client
+        mock_client.ping.return_value = True
+
+        with patch("util.cache.logger") as mock_logger:
+            client = RedisCache()
+
+            # Verify Redis client was created with local development parameters
+            mock_redis_class.assert_called_once_with(
+                host="localhost",
+                port=6379,  # Default port
+                password=None,  # No password by default
+                ssl=False,  # Local development doesn't use SSL
+                socket_connect_timeout=2,
+                socket_timeout=2,
+            )
+
+            # Verify connection test was performed
+            mock_client.ping.assert_called_once()
+
+            # Verify logging
+            assert mock_logger.info.call_count == 2
+            assert (
+                mock_logger.info.call_args_list[0][0][0]
+                == "Using local Redis configuration (REDIS_HOST)"
+            )
+            assert (
+                "Successfully connected to local Redis" in mock_logger.info.call_args_list[1][0][0]
+            )
+
+            # Verify client is available
+            assert client.client is not None
+
+    @patch.dict(
+        os.environ,
+        {"REDIS_HOST": "localhost", "REDIS_PORT": "6380", "REDIS_PASSWORD": "dev-pass"},
+        clear=False,
+    )
+    @patch("util.cache.redis.Redis")
+    def test_local_redis_with_custom_port_and_password(self, mock_redis_class):
+        """Test local Redis connection with custom port and password."""
+        mock_client = Mock()
+        mock_redis_class.return_value = mock_client
+        mock_client.ping.return_value = True
+
+        client = RedisCache()
+
+        # Verify Redis client was created with custom parameters
+        mock_redis_class.assert_called_once_with(
+            host="localhost",
+            port=6380,
+            password="dev-pass",
+            ssl=False,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
+        assert client.client is not None
+
+    @patch.dict(os.environ, {"REDIS_HOST": "localhost"}, clear=False)
+    @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
+    @patch("util.cache.get_redis_credentials")
+    @patch("util.cache.redis.Redis")
+    def test_local_redis_takes_precedence_over_secrets(
+        self, mock_redis_class, mock_get_creds, mock_redis_credentials
+    ):
+        """Test that REDIS_HOST takes precedence over REDIS_SECRET_ID."""
+        mock_get_creds.return_value = mock_redis_credentials
+        mock_client = Mock()
+        mock_redis_class.return_value = mock_client
+        mock_client.ping.return_value = True
+
+        with patch("util.cache.logger") as mock_logger:
+            client = RedisCache()
+
+            # Verify local Redis was used (not Secrets Manager)
+            assert "Using local Redis configuration" in mock_logger.info.call_args_list[0][0][0]
+            mock_redis_class.assert_called_once_with(
+                host="localhost",
+                port=6379,
+                password=None,
+                ssl=False,
+                socket_connect_timeout=2,
+                socket_timeout=2,
+            )
+            # Secrets Manager should not have been called
+            mock_get_creds.assert_not_called()
+
+    @patch.dict(os.environ, {"REDIS_HOST": "localhost"}, clear=False)
+    @patch("util.cache.redis.Redis")
+    def test_local_redis_connection_failure(self, mock_redis_class):
+        """Test graceful handling of local Redis connection failure."""
+        mock_client = Mock()
+        mock_redis_class.return_value = mock_client
+        mock_client.ping.side_effect = redis.ConnectionError("Connection refused")
+
+        with patch("util.cache.logger") as mock_logger:
+            client = RedisCache()
+
+            # Verify warning was logged
+            mock_logger.warning.assert_called_once()
+            assert "Failed to connect to local Redis" in mock_logger.warning.call_args[0][0]
+
+            # Verify client is None (graceful degradation)
             assert client.client is None
 
 
 class TestIsAvailable:
     """Test the is_available method."""
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", None)
     def test_is_available_with_no_client(self):
         """Test is_available when client is None."""
@@ -201,6 +326,7 @@ class TestIsAvailable:
 class TestGetMethod:
     """Test the get method."""
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", None)
     def test_get_with_unavailable_client(self):
         """Test get when client is unavailable."""
@@ -270,6 +396,7 @@ class TestGetMethod:
 class TestSetMethod:
     """Test the set method."""
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", None)
     def test_set_with_unavailable_client(self):
         """Test set when client is unavailable."""
@@ -336,6 +463,7 @@ class TestSetMethod:
 class TestHgetMethod:
     """Test the hget method."""
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", None)
     def test_hget_with_unavailable_client(self):
         """Test hget when client is unavailable."""
@@ -474,6 +602,7 @@ class TestHmgetMethod:
 class TestHmsetMethod:
     """Test the hmset method."""
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", None)
     def test_hmset_with_unavailable_client(self):
         """Test hmset when client is unavailable."""
@@ -550,6 +679,7 @@ class TestHmsetMethod:
 class TestHexistsMethod:
     """Test the hexists method."""
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", None)
     def test_hexists_with_unavailable_client(self):
         """Test hexists when client is unavailable."""

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -141,14 +141,14 @@ class TestRedisCacheInitialization:
         mock_redis_class.side_effect = Exception("Redis creation failed")
 
         with patch("util.cache.logger") as mock_logger:
-            client = RedisCache()
+            cache = RedisCache()
 
             # Verify warning was logged
             mock_logger.warning.assert_called_once()
             assert "Failed to connect to Redis" in mock_logger.warning.call_args[0][0]
 
             # Verify client is None
-            assert client.client is None
+            assert cache.client is None
 
     @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", None)
@@ -162,53 +162,55 @@ class TestRedisCacheInitialization:
             )
             assert client.client is None
 
-    @patch.dict(os.environ, {"REDIS_HOST": "localhost"}, clear=False)
-    @patch("util.cache.redis.Redis")
-    def test_local_redis_successful_connection(self, mock_redis_class):
+    def test_local_redis_successful_connection(self, monkeypatch):
         """Test successful connection to local Redis using REDIS_HOST."""
+        monkeypatch.setenv("REDIS_HOST", "localhost")
+
         mock_client = Mock()
-        mock_redis_class.return_value = mock_client
+        mock_redis_class = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.cache.redis.Redis", mock_redis_class)
+
         mock_client.ping.return_value = True
 
-        with patch("util.cache.logger") as mock_logger:
-            client = RedisCache()
+        mock_logger = Mock()
+        monkeypatch.setattr("util.cache.logger", mock_logger)
 
-            # Verify Redis client was created with local development parameters
-            mock_redis_class.assert_called_once_with(
-                host="localhost",
-                port=6379,  # Default port
-                password=None,  # No password by default
-                ssl=False,  # Local development doesn't use SSL
-                socket_connect_timeout=2,
-                socket_timeout=2,
-            )
+        client = RedisCache()
 
-            # Verify connection test was performed
-            mock_client.ping.assert_called_once()
+        # Verify Redis client was created with local development parameters
+        mock_redis_class.assert_called_once_with(
+            host="localhost",
+            port=6379,  # Default port
+            password=None,  # No password by default
+            ssl=False,  # Local development doesn't use SSL
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
 
-            # Verify logging
-            assert mock_logger.info.call_count == 2
-            assert (
-                mock_logger.info.call_args_list[0][0][0]
-                == "Using local Redis configuration (REDIS_HOST)"
-            )
-            assert (
-                "Successfully connected to local Redis" in mock_logger.info.call_args_list[1][0][0]
-            )
+        # Verify connection test was performed
+        mock_client.ping.assert_called_once()
 
-            # Verify client is available
-            assert client.client is not None
+        # Verify logging
+        assert mock_logger.info.call_count == 2
+        assert (
+            mock_logger.info.call_args_list[0][0][0]
+            == "Using local Redis configuration (REDIS_HOST)"
+        )
+        assert "Successfully connected to local Redis" in mock_logger.info.call_args_list[1][0][0]
 
-    @patch.dict(
-        os.environ,
-        {"REDIS_HOST": "localhost", "REDIS_PORT": "6380", "REDIS_PASSWORD": "dev-pass"},
-        clear=False,
-    )
-    @patch("util.cache.redis.Redis")
-    def test_local_redis_with_custom_port_and_password(self, mock_redis_class):
+        # Verify client is available
+        assert client.client is not None
+
+    def test_local_redis_with_custom_port_and_password(self, monkeypatch):
         """Test local Redis connection with custom port and password."""
+        monkeypatch.setenv("REDIS_HOST", "localhost")
+        monkeypatch.setenv("REDIS_PORT", "6380")
+        monkeypatch.setenv("REDIS_PASSWORD", "dev-pass")
+
         mock_client = Mock()
-        mock_redis_class.return_value = mock_client
+        mock_redis_class = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.cache.redis.Redis", mock_redis_class)
+
         mock_client.ping.return_value = True
 
         client = RedisCache()
@@ -224,52 +226,59 @@ class TestRedisCacheInitialization:
         )
         assert client.client is not None
 
-    @patch.dict(os.environ, {"REDIS_HOST": "localhost"}, clear=False)
-    @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
-    @patch("util.cache.get_redis_credentials")
-    @patch("util.cache.redis.Redis")
-    def test_local_redis_takes_precedence_over_secrets(
-        self, mock_redis_class, mock_get_creds, mock_redis_credentials
-    ):
+    def test_local_redis_takes_precedence_over_secrets(self, monkeypatch, mock_redis_credentials):
         """Test that REDIS_HOST takes precedence over REDIS_SECRET_ID."""
-        mock_get_creds.return_value = mock_redis_credentials
+        monkeypatch.setenv("REDIS_HOST", "localhost")
+        monkeypatch.setattr("util.cache.REDIS_SECRET_ID", "test-secret-arn")
+
+        mock_get_creds = Mock(return_value=mock_redis_credentials)
+        monkeypatch.setattr("util.cache.get_redis_credentials", mock_get_creds)
+
         mock_client = Mock()
-        mock_redis_class.return_value = mock_client
+        mock_redis_class = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.cache.redis.Redis", mock_redis_class)
+
         mock_client.ping.return_value = True
 
-        with patch("util.cache.logger") as mock_logger:
-            client = RedisCache()
+        mock_logger = Mock()
+        monkeypatch.setattr("util.cache.logger", mock_logger)
 
-            # Verify local Redis was used (not Secrets Manager)
-            assert "Using local Redis configuration" in mock_logger.info.call_args_list[0][0][0]
-            mock_redis_class.assert_called_once_with(
-                host="localhost",
-                port=6379,
-                password=None,
-                ssl=False,
-                socket_connect_timeout=2,
-                socket_timeout=2,
-            )
-            # Secrets Manager should not have been called
-            mock_get_creds.assert_not_called()
+        RedisCache()
 
-    @patch.dict(os.environ, {"REDIS_HOST": "localhost"}, clear=False)
-    @patch("util.cache.redis.Redis")
-    def test_local_redis_connection_failure(self, mock_redis_class):
+        # Verify local Redis was used (not Secrets Manager)
+        assert "Using local Redis configuration" in mock_logger.info.call_args_list[0][0][0]
+        mock_redis_class.assert_called_once_with(
+            host="localhost",
+            port=6379,
+            password=None,
+            ssl=False,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
+        # Secrets Manager should not have been called
+        mock_get_creds.assert_not_called()
+
+    def test_local_redis_connection_failure(self, monkeypatch):
         """Test graceful handling of local Redis connection failure."""
+        monkeypatch.setenv("REDIS_HOST", "localhost")
+
         mock_client = Mock()
-        mock_redis_class.return_value = mock_client
+        mock_redis_class = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.cache.redis.Redis", mock_redis_class)
+
         mock_client.ping.side_effect = redis.ConnectionError("Connection refused")
 
-        with patch("util.cache.logger") as mock_logger:
-            client = RedisCache()
+        mock_logger = Mock()
+        monkeypatch.setattr("util.cache.logger", mock_logger)
 
-            # Verify warning was logged
-            mock_logger.warning.assert_called_once()
-            assert "Failed to connect to local Redis" in mock_logger.warning.call_args[0][0]
+        client = RedisCache()
 
-            # Verify client is None (graceful degradation)
-            assert client.client is None
+        # Verify warning was logged
+        mock_logger.warning.assert_called_once()
+        assert "Failed to connect to local Redis" in mock_logger.warning.call_args[0][0]
+
+        # Verify client is None (graceful degradation)
+        assert client.client is None
 
 
 class TestIsAvailable:

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -214,7 +214,7 @@ class TestRedisCacheInitialization:
         mock_redis_class.assert_called_once_with(
             host="localhost",
             port=6380,
-            password="dev-pass",
+            password="dev-pass",  # noqa: S106 - Suppress linting warning, not a real password
             ssl=False,
             socket_connect_timeout=2,
             socket_timeout=2,
@@ -273,6 +273,23 @@ class TestRedisCacheInitialization:
 
         assert client.client is None
 
+    def test_local_redis_creation_failure(self, monkeypatch):
+        """Test graceful handling when the Redis constructor raises with REDIS_HOST set."""
+        monkeypatch.setenv("REDIS_HOST", "localhost")
+
+        mock_redis_class = Mock(side_effect=Exception("Redis creation failed"))
+        monkeypatch.setattr("util.cache.redis.Redis", mock_redis_class)
+
+        mock_logger = Mock()
+        monkeypatch.setattr("util.cache.logger", mock_logger)
+
+        client = RedisCache()
+
+        mock_logger.warning.assert_called_once()
+        assert "Failed to connect to local Redis" in mock_logger.warning.call_args[0][0]
+
+        assert client.client is None
+
 
 class TestIsAvailable:
     """Test the is_available method."""
@@ -285,6 +302,7 @@ class TestIsAvailable:
 
         assert client.is_available() is False
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -305,6 +323,7 @@ class TestIsAvailable:
         # Verify ping was called at least twice (once in init, once in is_available)
         assert mock_client.ping.call_count >= 2
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -338,6 +357,7 @@ class TestGetMethod:
 
         assert result is None
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -359,6 +379,7 @@ class TestGetMethod:
         assert result == test_data
         mock_client.get.assert_called_with("test_key")
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -375,6 +396,7 @@ class TestGetMethod:
         assert result is None
         mock_client.get.assert_called_with("nonexistent_key")
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -408,6 +430,7 @@ class TestSetMethod:
 
         assert result is False
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -425,6 +448,7 @@ class TestSetMethod:
         assert result is True
         mock_client.setex.assert_called_once_with("test_key", 600, json.dumps(test_data))
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -442,6 +466,7 @@ class TestSetMethod:
         assert result is True
         mock_client.setex.assert_called_once_with("test_key", 900, json.dumps(test_data))
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -475,6 +500,7 @@ class TestHgetMethod:
 
         assert result is None
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -495,6 +521,7 @@ class TestHgetMethod:
         assert result == test_data
         mock_client.hget.assert_called_with("kms:scheme:instruments", "MODIS")
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -510,6 +537,7 @@ class TestHgetMethod:
 
         assert result is None
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -543,6 +571,7 @@ class TestHmgetMethod:
 
         assert result == {"field1": None, "field2": None}
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -564,6 +593,7 @@ class TestHmgetMethod:
         assert result == {"MODIS": data1, "ASTER": data2}
         mock_client.hmget.assert_called_with("kms:scheme:instruments", ["MODIS", "ASTER"])
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -582,6 +612,7 @@ class TestHmgetMethod:
         assert result["MODIS"] == data1
         assert result["MISSING"] is None
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -615,6 +646,7 @@ class TestHmsetMethod:
 
         assert result is False
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -642,6 +674,7 @@ class TestHmsetMethod:
         # Verify TTL was set
         mock_client.expire.assert_called_once_with("kms:scheme:instruments", 86400)
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -659,6 +692,7 @@ class TestHmsetMethod:
         assert result is True
         mock_client.hset.assert_not_called()
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -692,6 +726,7 @@ class TestHexistsMethod:
 
         assert result is False
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -710,6 +745,7 @@ class TestHexistsMethod:
         assert result is True
         mock_client.exists.assert_called_with("kms:scheme:instruments")
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")
@@ -727,6 +763,7 @@ class TestHexistsMethod:
 
         assert result is False
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", "test-secret-arn")
     @patch("util.cache.get_redis_credentials")
     @patch("util.cache.redis.Redis")

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -533,6 +533,7 @@ class TestHgetMethod:
 class TestHmgetMethod:
     """Test the hmget method."""
 
+    @patch.dict(os.environ, {"REDIS_HOST": ""}, clear=False)
     @patch("util.cache.REDIS_SECRET_ID", None)
     def test_hmget_with_unavailable_client(self):
         """Test hmget when client is unavailable."""

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -177,20 +177,17 @@ class TestRedisCacheInitialization:
 
         client = RedisCache()
 
-        # Verify Redis client was created with local development parameters
         mock_redis_class.assert_called_once_with(
             host="localhost",
             port=6379,  # Default port
-            password=None,  # No password by default
+            password=None,
             ssl=False,  # Local development doesn't use SSL
             socket_connect_timeout=2,
             socket_timeout=2,
         )
 
-        # Verify connection test was performed
         mock_client.ping.assert_called_once()
 
-        # Verify logging
         assert mock_logger.info.call_count == 2
         assert (
             mock_logger.info.call_args_list[0][0][0]
@@ -198,7 +195,6 @@ class TestRedisCacheInitialization:
         )
         assert "Successfully connected to local Redis" in mock_logger.info.call_args_list[1][0][0]
 
-        # Verify client is available
         assert client.client is not None
 
     def test_local_redis_with_custom_port_and_password(self, monkeypatch):
@@ -215,7 +211,6 @@ class TestRedisCacheInitialization:
 
         client = RedisCache()
 
-        # Verify Redis client was created with custom parameters
         mock_redis_class.assert_called_once_with(
             host="localhost",
             port=6380,
@@ -273,11 +268,9 @@ class TestRedisCacheInitialization:
 
         client = RedisCache()
 
-        # Verify warning was logged
         mock_logger.warning.assert_called_once()
         assert "Failed to connect to local Redis" in mock_logger.warning.call_args[0][0]
 
-        # Verify client is None (graceful degradation)
         assert client.client is None
 
 

--- a/tests/utils/test_database.py
+++ b/tests/utils/test_database.py
@@ -67,11 +67,9 @@ class TestGetDatabaseCredentials:
             "SecretString": json.dumps({"url": "postgresql://user:pass@db.example.com:5432/mydb"})
         }
 
-        # Call twice
         result1 = get_database_credentials()
         result2 = get_database_credentials()
 
-        # Should only call Secrets Manager once (cached)
         assert mock_client.get_secret_value.call_count == 1
         assert result1 == result2
 
@@ -258,7 +256,6 @@ class TestGetDbConnection:
             "SecretString": json.dumps({"url": "postgresql://user:pass@db.example.com:5432/mydb"})
         }
 
-        # Create a healthy connection
         mock_conn = Mock()
         mock_conn.closed = False
         mock_transaction = Mock()
@@ -278,7 +275,6 @@ class TestGetDbConnection:
 
         conn = get_db_connection()
 
-        # Should not create a new connection
         mock_connect.assert_not_called()
         assert conn == mock_conn
 
@@ -300,7 +296,6 @@ class TestGetDbConnection:
         old_conn = Mock()
         old_conn.closed = True
 
-        # New healthy connection
         new_conn = Mock()
         new_conn.closed = False
         mock_connect = Mock(return_value=new_conn)
@@ -316,7 +311,6 @@ class TestGetDbConnection:
 
         conn = get_db_connection()
 
-        # Should close old connection and create new one
         old_conn.close.assert_called_once()
         mock_connect.assert_called_once()
         mock_register.assert_called_once_with(new_conn)
@@ -354,11 +348,9 @@ class TestGetDbConnection:
 
         conn = get_db_connection()
 
-        # Should connect with localhost instead of prod-db.example.com
         mock_connect.assert_called_once_with(
             "postgresql://user:pass@localhost:5432/mydb", autocommit=True
         )
-        # Check that DB_HOST override was logged
         log_messages = [str(call) for call in mock_logger.info.call_args_list]
         assert any("DB_HOST" in msg for msg in log_messages)
         assert conn == mock_conn

--- a/tests/utils/test_database.py
+++ b/tests/utils/test_database.py
@@ -1,0 +1,329 @@
+"""Tests for database utility."""
+
+import json
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from util.database import (
+    _get_connection_url,
+    _is_connection_healthy,
+    get_database_credentials,
+    get_db_connection,
+)
+
+
+class TestGetDatabaseCredentials:
+    """Test get_database_credentials function."""
+
+    @patch("util.database.DATABASE_SECRET_ID", None)
+    def test_raises_error_without_secret_id(self):
+        """Should raise RuntimeError when DATABASE_SECRET_ID is not set."""
+        # Clear the lru_cache to ensure fresh state
+        get_database_credentials.cache_clear()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            get_database_credentials()
+
+        assert "DATABASE_SECRET_ID environment variable is not set" in str(exc_info.value)
+
+    @patch("util.database.DATABASE_SECRET_ID", "test-db-secret-arn")
+    @patch("util.database.get_secrets_client")
+    def test_fetches_credentials_from_secrets_manager(self, mock_get_client):
+        """Should fetch credentials from Secrets Manager."""
+        get_database_credentials.cache_clear()
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_secret_value.return_value = {
+            "SecretString": json.dumps(
+                {
+                    "url": "postgresql://user:pass@db.example.com:5432/mydb",
+                    "username": "dbuser",
+                    "password": "dbpass",
+                }
+            )
+        }
+
+        result = get_database_credentials()
+
+        mock_client.get_secret_value.assert_called_once_with(SecretId="test-db-secret-arn")
+        assert result["url"] == "postgresql://user:pass@db.example.com:5432/mydb"
+        assert result["username"] == "dbuser"
+
+    @patch("util.database.DATABASE_SECRET_ID", "test-db-secret-arn")
+    @patch("util.database.get_secrets_client")
+    def test_caches_credentials(self, mock_get_client):
+        """Should cache credentials across multiple calls."""
+        get_database_credentials.cache_clear()
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_secret_value.return_value = {
+            "SecretString": json.dumps({"url": "postgresql://user:pass@db.example.com:5432/mydb"})
+        }
+
+        # Call twice
+        result1 = get_database_credentials()
+        result2 = get_database_credentials()
+
+        # Should only call Secrets Manager once (cached)
+        assert mock_client.get_secret_value.call_count == 1
+        assert result1 == result2
+
+
+class TestGetConnectionUrl:
+    """Test _get_connection_url function."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
+    @patch("util.database.get_secrets_client")
+    def test_returns_url_without_override(self, mock_get_client):
+        """Should return URL as-is when DB_HOST is not set."""
+        get_database_credentials.cache_clear()
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_secret_value.return_value = {
+            "SecretString": json.dumps(
+                {"url": "postgresql://user:pass@prod-db.example.com:5432/mydb"}
+            )
+        }
+
+        url = _get_connection_url()
+
+        assert url == "postgresql://user:pass@prod-db.example.com:5432/mydb"
+
+    @patch.dict(os.environ, {"DB_HOST": "localhost"}, clear=False)
+    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
+    @patch("util.database.get_secrets_client")
+    def test_overrides_host_with_db_host(self, mock_get_client):
+        """Should override hostname when DB_HOST is set."""
+        get_database_credentials.cache_clear()
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_secret_value.return_value = {
+            "SecretString": json.dumps(
+                {"url": "postgresql://user:pass@prod-db.example.com:5432/mydb"}
+            )
+        }
+
+        with patch("util.database.logger") as mock_logger:
+            url = _get_connection_url()
+
+            assert url == "postgresql://user:pass@localhost:5432/mydb"
+            mock_logger.info.assert_called_once_with("Using DB_HOST override: %s", "localhost")
+
+    @patch.dict(os.environ, {"DB_HOST": "127.0.0.1"}, clear=False)
+    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
+    @patch("util.database.get_secrets_client")
+    def test_overrides_host_with_ip_address(self, mock_get_client):
+        """Should override hostname with IP address when DB_HOST is set."""
+        get_database_credentials.cache_clear()
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_secret_value.return_value = {
+            "SecretString": json.dumps(
+                {"url": "postgresql://dbuser:dbpass@rds.amazonaws.com:5432/production"}
+            )
+        }
+
+        url = _get_connection_url()
+
+        assert url == "postgresql://dbuser:dbpass@127.0.0.1:5432/production"
+
+    @patch.dict(os.environ, {"DB_HOST": "dev-db.local"}, clear=False)
+    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
+    @patch("util.database.get_secrets_client")
+    def test_preserves_port_and_credentials(self, mock_get_client):
+        """Should preserve port and credentials when overriding host."""
+        get_database_credentials.cache_clear()
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_secret_value.return_value = {
+            "SecretString": json.dumps(
+                {"url": "postgresql://myuser:mypassword@original.host:5433/dbname"}
+            )
+        }
+
+        url = _get_connection_url()
+
+        assert url == "postgresql://myuser:mypassword@dev-db.local:5433/dbname"
+
+
+class TestIsConnectionHealthy:
+    """Test _is_connection_healthy function."""
+
+    def test_returns_false_for_none(self):
+        """Should return False when connection is None."""
+        assert _is_connection_healthy(None) is False
+
+    def test_returns_false_for_closed_connection(self):
+        """Should return False when connection is closed."""
+        mock_conn = Mock()
+        mock_conn.closed = True
+
+        assert _is_connection_healthy(mock_conn) is False
+
+    def test_returns_true_for_healthy_connection(self):
+        """Should return True when connection responds to SELECT 1."""
+        mock_conn = Mock()
+        mock_conn.closed = False
+        mock_transaction = Mock()
+        mock_cursor = Mock()
+
+        mock_conn.transaction.return_value.__enter__ = Mock(return_value=mock_transaction)
+        mock_conn.transaction.return_value.__exit__ = Mock(return_value=None)
+        mock_conn.cursor.return_value.__enter__ = Mock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = Mock(return_value=None)
+
+        assert _is_connection_healthy(mock_conn) is True
+        mock_cursor.execute.assert_called_once_with("SELECT 1")
+
+    def test_returns_false_on_query_exception(self):
+        """Should return False when health check query fails."""
+        mock_conn = Mock()
+        mock_conn.closed = False
+        mock_conn.transaction.side_effect = Exception("Connection lost")
+
+        assert _is_connection_healthy(mock_conn) is False
+
+
+class TestGetDbConnection:
+    """Test get_db_connection function."""
+
+    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
+    @patch("util.database.get_secrets_client")
+    @patch("util.database.psycopg.connect")
+    @patch("util.database.register_vector")
+    @patch("util.database._connection", None)
+    def test_creates_new_connection_when_none_exists(
+        self, mock_register, mock_connect, mock_get_client
+    ):
+        """Should create a new connection when none exists."""
+        get_database_credentials.cache_clear()
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_secret_value.return_value = {
+            "SecretString": json.dumps({"url": "postgresql://user:pass@db.example.com:5432/mydb"})
+        }
+
+        mock_conn = Mock()
+        mock_conn.closed = False
+        mock_connect.return_value = mock_conn
+
+        with patch("util.database.logger") as mock_logger:
+            conn = get_db_connection()
+
+            mock_connect.assert_called_once_with(
+                "postgresql://user:pass@db.example.com:5432/mydb", autocommit=True
+            )
+            mock_register.assert_called_once_with(mock_conn)
+            mock_logger.info.assert_called_once_with("Created new database connection")
+            assert conn == mock_conn
+
+    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
+    @patch("util.database.get_secrets_client")
+    @patch("util.database.psycopg.connect")
+    @patch("util.database.register_vector")
+    def test_reuses_healthy_connection(self, mock_register, mock_connect, mock_get_client):
+        """Should reuse existing healthy connection."""
+        get_database_credentials.cache_clear()
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_secret_value.return_value = {
+            "SecretString": json.dumps({"url": "postgresql://user:pass@db.example.com:5432/mydb"})
+        }
+
+        # Create a healthy connection
+        mock_conn = Mock()
+        mock_conn.closed = False
+        mock_transaction = Mock()
+        mock_cursor = Mock()
+        mock_conn.transaction.return_value.__enter__ = Mock(return_value=mock_transaction)
+        mock_conn.transaction.return_value.__exit__ = Mock(return_value=None)
+        mock_conn.cursor.return_value.__enter__ = Mock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = Mock(return_value=None)
+
+        with patch("util.database._connection", mock_conn):
+            conn = get_db_connection()
+
+            # Should not create a new connection
+            mock_connect.assert_not_called()
+            assert conn == mock_conn
+
+    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
+    @patch("util.database.get_secrets_client")
+    @patch("util.database.psycopg.connect")
+    @patch("util.database.register_vector")
+    def test_recreates_connection_when_unhealthy(
+        self, mock_register, mock_connect, mock_get_client
+    ):
+        """Should create new connection when existing one is unhealthy."""
+        get_database_credentials.cache_clear()
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_secret_value.return_value = {
+            "SecretString": json.dumps({"url": "postgresql://user:pass@db.example.com:5432/mydb"})
+        }
+
+        # Create an unhealthy (closed) connection
+        old_conn = Mock()
+        old_conn.closed = True
+
+        # New healthy connection
+        new_conn = Mock()
+        new_conn.closed = False
+        mock_connect.return_value = new_conn
+
+        with patch("util.database._connection", old_conn):
+            with patch("util.database.logger") as mock_logger:
+                conn = get_db_connection()
+
+                # Should close old connection and create new one
+                old_conn.close.assert_called_once()
+                mock_connect.assert_called_once()
+                mock_register.assert_called_once_with(new_conn)
+                mock_logger.info.assert_called_once_with("Created new database connection")
+                assert conn == new_conn
+
+    @patch.dict(os.environ, {"DB_HOST": "localhost"}, clear=False)
+    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
+    @patch("util.database.get_secrets_client")
+    @patch("util.database.psycopg.connect")
+    @patch("util.database.register_vector")
+    @patch("util.database._connection", None)
+    def test_uses_db_host_override(self, mock_register, mock_connect, mock_get_client):
+        """Should use DB_HOST override when connecting."""
+        get_database_credentials.cache_clear()
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_client.get_secret_value.return_value = {
+            "SecretString": json.dumps(
+                {"url": "postgresql://user:pass@prod-db.example.com:5432/mydb"}
+            )
+        }
+
+        mock_conn = Mock()
+        mock_conn.closed = False
+        mock_connect.return_value = mock_conn
+
+        with patch("util.database.logger") as mock_logger:
+            conn = get_db_connection()
+
+            # Should connect with localhost instead of prod-db.example.com
+            mock_connect.assert_called_once_with(
+                "postgresql://user:pass@localhost:5432/mydb", autocommit=True
+            )
+            # Check that DB_HOST override was logged
+            log_messages = [str(call) for call in mock_logger.info.call_args_list]
+            assert any("DB_HOST" in msg for msg in log_messages)
+            assert conn == mock_conn

--- a/tests/utils/test_database.py
+++ b/tests/utils/test_database.py
@@ -1,8 +1,7 @@
 """Tests for database utility."""
 
 import json
-import os
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -17,9 +16,9 @@ from util.database import (
 class TestGetDatabaseCredentials:
     """Test get_database_credentials function."""
 
-    @patch("util.database.DATABASE_SECRET_ID", None)
-    def test_raises_error_without_secret_id(self):
+    def test_raises_error_without_secret_id(self, monkeypatch):
         """Should raise RuntimeError when DATABASE_SECRET_ID is not set."""
+        monkeypatch.setattr("util.database.DATABASE_SECRET_ID", None)
         # Clear the lru_cache to ensure fresh state
         get_database_credentials.cache_clear()
 
@@ -28,14 +27,16 @@ class TestGetDatabaseCredentials:
 
         assert "DATABASE_SECRET_ID environment variable is not set" in str(exc_info.value)
 
-    @patch("util.database.DATABASE_SECRET_ID", "test-db-secret-arn")
-    @patch("util.database.get_secrets_client")
-    def test_fetches_credentials_from_secrets_manager(self, mock_get_client):
+    def test_fetches_credentials_from_secrets_manager(self, monkeypatch):
         """Should fetch credentials from Secrets Manager."""
-        get_database_credentials.cache_clear()
+        monkeypatch.setattr("util.database.DATABASE_SECRET_ID", "test-db-secret-arn")
 
         mock_client = Mock()
-        mock_get_client.return_value = mock_client
+        mock_get_client = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.database.get_secrets_client", mock_get_client)
+
+        get_database_credentials.cache_clear()
+
         mock_client.get_secret_value.return_value = {
             "SecretString": json.dumps(
                 {
@@ -52,14 +53,16 @@ class TestGetDatabaseCredentials:
         assert result["url"] == "postgresql://user:pass@db.example.com:5432/mydb"
         assert result["username"] == "dbuser"
 
-    @patch("util.database.DATABASE_SECRET_ID", "test-db-secret-arn")
-    @patch("util.database.get_secrets_client")
-    def test_caches_credentials(self, mock_get_client):
+    def test_caches_credentials(self, monkeypatch):
         """Should cache credentials across multiple calls."""
-        get_database_credentials.cache_clear()
+        monkeypatch.setattr("util.database.DATABASE_SECRET_ID", "test-db-secret-arn")
 
         mock_client = Mock()
-        mock_get_client.return_value = mock_client
+        mock_get_client = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.database.get_secrets_client", mock_get_client)
+
+        get_database_credentials.cache_clear()
+
         mock_client.get_secret_value.return_value = {
             "SecretString": json.dumps({"url": "postgresql://user:pass@db.example.com:5432/mydb"})
         }
@@ -76,15 +79,17 @@ class TestGetDatabaseCredentials:
 class TestGetConnectionUrl:
     """Test _get_connection_url function."""
 
-    @patch.dict(os.environ, {}, clear=True)
-    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
-    @patch("util.database.get_secrets_client")
-    def test_returns_url_without_override(self, mock_get_client):
+    def test_returns_url_without_override(self, monkeypatch):
         """Should return URL as-is when DB_HOST is not set."""
-        get_database_credentials.cache_clear()
+        monkeypatch.delenv("DB_HOST", raising=False)
+        monkeypatch.setattr("util.database.DATABASE_SECRET_ID", "test-secret")
 
         mock_client = Mock()
-        mock_get_client.return_value = mock_client
+        mock_get_client = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.database.get_secrets_client", mock_get_client)
+
+        get_database_credentials.cache_clear()
+
         mock_client.get_secret_value.return_value = {
             "SecretString": json.dumps(
                 {"url": "postgresql://user:pass@prod-db.example.com:5432/mydb"}
@@ -95,36 +100,42 @@ class TestGetConnectionUrl:
 
         assert url == "postgresql://user:pass@prod-db.example.com:5432/mydb"
 
-    @patch.dict(os.environ, {"DB_HOST": "localhost"}, clear=False)
-    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
-    @patch("util.database.get_secrets_client")
-    def test_overrides_host_with_db_host(self, mock_get_client):
+    def test_overrides_host_with_db_host(self, monkeypatch):
         """Should override hostname when DB_HOST is set."""
-        get_database_credentials.cache_clear()
+        monkeypatch.setenv("DB_HOST", "localhost")
+        monkeypatch.setattr("util.database.DATABASE_SECRET_ID", "test-secret")
 
         mock_client = Mock()
-        mock_get_client.return_value = mock_client
+        mock_get_client = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.database.get_secrets_client", mock_get_client)
+
+        get_database_credentials.cache_clear()
+
         mock_client.get_secret_value.return_value = {
             "SecretString": json.dumps(
                 {"url": "postgresql://user:pass@prod-db.example.com:5432/mydb"}
             )
         }
 
-        with patch("util.database.logger") as mock_logger:
-            url = _get_connection_url()
+        mock_logger = Mock()
+        monkeypatch.setattr("util.database.logger", mock_logger)
 
-            assert url == "postgresql://user:pass@localhost:5432/mydb"
-            mock_logger.info.assert_called_once_with("Using DB_HOST override: %s", "localhost")
+        url = _get_connection_url()
 
-    @patch.dict(os.environ, {"DB_HOST": "127.0.0.1"}, clear=False)
-    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
-    @patch("util.database.get_secrets_client")
-    def test_overrides_host_with_ip_address(self, mock_get_client):
+        assert url == "postgresql://user:pass@localhost:5432/mydb"
+        mock_logger.info.assert_called_once_with("Using DB_HOST override: %s", "localhost")
+
+    def test_overrides_host_with_ip_address(self, monkeypatch):
         """Should override hostname with IP address when DB_HOST is set."""
-        get_database_credentials.cache_clear()
+        monkeypatch.setenv("DB_HOST", "127.0.0.1")
+        monkeypatch.setattr("util.database.DATABASE_SECRET_ID", "test-secret")
 
         mock_client = Mock()
-        mock_get_client.return_value = mock_client
+        mock_get_client = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.database.get_secrets_client", mock_get_client)
+
+        get_database_credentials.cache_clear()
+
         mock_client.get_secret_value.return_value = {
             "SecretString": json.dumps(
                 {"url": "postgresql://dbuser:dbpass@rds.amazonaws.com:5432/production"}
@@ -135,15 +146,17 @@ class TestGetConnectionUrl:
 
         assert url == "postgresql://dbuser:dbpass@127.0.0.1:5432/production"
 
-    @patch.dict(os.environ, {"DB_HOST": "dev-db.local"}, clear=False)
-    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
-    @patch("util.database.get_secrets_client")
-    def test_preserves_port_and_credentials(self, mock_get_client):
+    def test_preserves_port_and_credentials(self, monkeypatch):
         """Should preserve port and credentials when overriding host."""
-        get_database_credentials.cache_clear()
+        monkeypatch.setenv("DB_HOST", "dev-db.local")
+        monkeypatch.setattr("util.database.DATABASE_SECRET_ID", "test-secret")
 
         mock_client = Mock()
-        mock_get_client.return_value = mock_client
+        mock_get_client = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.database.get_secrets_client", mock_get_client)
+
+        get_database_credentials.cache_clear()
+
         mock_client.get_secret_value.return_value = {
             "SecretString": json.dumps(
                 {"url": "postgresql://myuser:mypassword@original.host:5433/dbname"}
@@ -196,47 +209,51 @@ class TestIsConnectionHealthy:
 class TestGetDbConnection:
     """Test get_db_connection function."""
 
-    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
-    @patch("util.database.get_secrets_client")
-    @patch("util.database.psycopg.connect")
-    @patch("util.database.register_vector")
-    @patch("util.database._connection", None)
-    def test_creates_new_connection_when_none_exists(
-        self, mock_register, mock_connect, mock_get_client
-    ):
+    def test_creates_new_connection_when_none_exists(self, monkeypatch):
         """Should create a new connection when none exists."""
-        get_database_credentials.cache_clear()
+        monkeypatch.setattr("util.database.DATABASE_SECRET_ID", "test-secret")
+        monkeypatch.setattr("util.database._connection", None)
 
         mock_client = Mock()
-        mock_get_client.return_value = mock_client
+        mock_get_client = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.database.get_secrets_client", mock_get_client)
+
+        get_database_credentials.cache_clear()
+
         mock_client.get_secret_value.return_value = {
             "SecretString": json.dumps({"url": "postgresql://user:pass@db.example.com:5432/mydb"})
         }
 
         mock_conn = Mock()
         mock_conn.closed = False
-        mock_connect.return_value = mock_conn
+        mock_connect = Mock(return_value=mock_conn)
+        monkeypatch.setattr("util.database.psycopg.connect", mock_connect)
 
-        with patch("util.database.logger") as mock_logger:
-            conn = get_db_connection()
+        mock_register = Mock()
+        monkeypatch.setattr("util.database.register_vector", mock_register)
 
-            mock_connect.assert_called_once_with(
-                "postgresql://user:pass@db.example.com:5432/mydb", autocommit=True
-            )
-            mock_register.assert_called_once_with(mock_conn)
-            mock_logger.info.assert_called_once_with("Created new database connection")
-            assert conn == mock_conn
+        mock_logger = Mock()
+        monkeypatch.setattr("util.database.logger", mock_logger)
 
-    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
-    @patch("util.database.get_secrets_client")
-    @patch("util.database.psycopg.connect")
-    @patch("util.database.register_vector")
-    def test_reuses_healthy_connection(self, mock_register, mock_connect, mock_get_client):
+        conn = get_db_connection()
+
+        mock_connect.assert_called_once_with(
+            "postgresql://user:pass@db.example.com:5432/mydb", autocommit=True
+        )
+        mock_register.assert_called_once_with(mock_conn)
+        mock_logger.info.assert_called_once_with("Created new database connection")
+        assert conn == mock_conn
+
+    def test_reuses_healthy_connection(self, monkeypatch):
         """Should reuse existing healthy connection."""
-        get_database_credentials.cache_clear()
+        monkeypatch.setattr("util.database.DATABASE_SECRET_ID", "test-secret")
 
         mock_client = Mock()
-        mock_get_client.return_value = mock_client
+        mock_get_client = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.database.get_secrets_client", mock_get_client)
+
+        get_database_credentials.cache_clear()
+
         mock_client.get_secret_value.return_value = {
             "SecretString": json.dumps({"url": "postgresql://user:pass@db.example.com:5432/mydb"})
         }
@@ -251,25 +268,30 @@ class TestGetDbConnection:
         mock_conn.cursor.return_value.__enter__ = Mock(return_value=mock_cursor)
         mock_conn.cursor.return_value.__exit__ = Mock(return_value=None)
 
-        with patch("util.database._connection", mock_conn):
-            conn = get_db_connection()
+        monkeypatch.setattr("util.database._connection", mock_conn)
 
-            # Should not create a new connection
-            mock_connect.assert_not_called()
-            assert conn == mock_conn
+        mock_connect = Mock()
+        monkeypatch.setattr("util.database.psycopg.connect", mock_connect)
 
-    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
-    @patch("util.database.get_secrets_client")
-    @patch("util.database.psycopg.connect")
-    @patch("util.database.register_vector")
-    def test_recreates_connection_when_unhealthy(
-        self, mock_register, mock_connect, mock_get_client
-    ):
+        mock_register = Mock()
+        monkeypatch.setattr("util.database.register_vector", mock_register)
+
+        conn = get_db_connection()
+
+        # Should not create a new connection
+        mock_connect.assert_not_called()
+        assert conn == mock_conn
+
+    def test_recreates_connection_when_unhealthy(self, monkeypatch):
         """Should create new connection when existing one is unhealthy."""
-        get_database_credentials.cache_clear()
+        monkeypatch.setattr("util.database.DATABASE_SECRET_ID", "test-secret")
 
         mock_client = Mock()
-        mock_get_client.return_value = mock_client
+        mock_get_client = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.database.get_secrets_client", mock_get_client)
+
+        get_database_credentials.cache_clear()
+
         mock_client.get_secret_value.return_value = {
             "SecretString": json.dumps({"url": "postgresql://user:pass@db.example.com:5432/mydb"})
         }
@@ -281,31 +303,38 @@ class TestGetDbConnection:
         # New healthy connection
         new_conn = Mock()
         new_conn.closed = False
-        mock_connect.return_value = new_conn
+        mock_connect = Mock(return_value=new_conn)
+        monkeypatch.setattr("util.database.psycopg.connect", mock_connect)
 
-        with patch("util.database._connection", old_conn):
-            with patch("util.database.logger") as mock_logger:
-                conn = get_db_connection()
+        mock_register = Mock()
+        monkeypatch.setattr("util.database.register_vector", mock_register)
 
-                # Should close old connection and create new one
-                old_conn.close.assert_called_once()
-                mock_connect.assert_called_once()
-                mock_register.assert_called_once_with(new_conn)
-                mock_logger.info.assert_called_once_with("Created new database connection")
-                assert conn == new_conn
+        monkeypatch.setattr("util.database._connection", old_conn)
 
-    @patch.dict(os.environ, {"DB_HOST": "localhost"}, clear=False)
-    @patch("util.database.DATABASE_SECRET_ID", "test-secret")
-    @patch("util.database.get_secrets_client")
-    @patch("util.database.psycopg.connect")
-    @patch("util.database.register_vector")
-    @patch("util.database._connection", None)
-    def test_uses_db_host_override(self, mock_register, mock_connect, mock_get_client):
+        mock_logger = Mock()
+        monkeypatch.setattr("util.database.logger", mock_logger)
+
+        conn = get_db_connection()
+
+        # Should close old connection and create new one
+        old_conn.close.assert_called_once()
+        mock_connect.assert_called_once()
+        mock_register.assert_called_once_with(new_conn)
+        mock_logger.info.assert_called_once_with("Created new database connection")
+        assert conn == new_conn
+
+    def test_uses_db_host_override(self, monkeypatch):
         """Should use DB_HOST override when connecting."""
-        get_database_credentials.cache_clear()
+        monkeypatch.setenv("DB_HOST", "localhost")
+        monkeypatch.setattr("util.database.DATABASE_SECRET_ID", "test-secret")
+        monkeypatch.setattr("util.database._connection", None)
 
         mock_client = Mock()
-        mock_get_client.return_value = mock_client
+        mock_get_client = Mock(return_value=mock_client)
+        monkeypatch.setattr("util.database.get_secrets_client", mock_get_client)
+
+        get_database_credentials.cache_clear()
+
         mock_client.get_secret_value.return_value = {
             "SecretString": json.dumps(
                 {"url": "postgresql://user:pass@prod-db.example.com:5432/mydb"}
@@ -314,16 +343,22 @@ class TestGetDbConnection:
 
         mock_conn = Mock()
         mock_conn.closed = False
-        mock_connect.return_value = mock_conn
+        mock_connect = Mock(return_value=mock_conn)
+        monkeypatch.setattr("util.database.psycopg.connect", mock_connect)
 
-        with patch("util.database.logger") as mock_logger:
-            conn = get_db_connection()
+        mock_register = Mock()
+        monkeypatch.setattr("util.database.register_vector", mock_register)
 
-            # Should connect with localhost instead of prod-db.example.com
-            mock_connect.assert_called_once_with(
-                "postgresql://user:pass@localhost:5432/mydb", autocommit=True
-            )
-            # Check that DB_HOST override was logged
-            log_messages = [str(call) for call in mock_logger.info.call_args_list]
-            assert any("DB_HOST" in msg for msg in log_messages)
-            assert conn == mock_conn
+        mock_logger = Mock()
+        monkeypatch.setattr("util.database.logger", mock_logger)
+
+        conn = get_db_connection()
+
+        # Should connect with localhost instead of prod-db.example.com
+        mock_connect.assert_called_once_with(
+            "postgresql://user:pass@localhost:5432/mydb", autocommit=True
+        )
+        # Check that DB_HOST override was logged
+        log_messages = [str(call) for call in mock_logger.info.call_args_list]
+        assert any("DB_HOST" in msg for msg in log_messages)
+        assert conn == mock_conn

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -26,36 +26,30 @@ class TestGetEnvironment:
 
         assert get_environment() == "test"
 
-    def test_defaults_to_local_when_unset(self, monkeypatch):
-        """Should default to 'local' when ENVIRONMENT_NAME is not set."""
+    def test_defaults_to_development_when_unset(self, monkeypatch):
+        """Should default to 'development' when ENVIRONMENT_NAME is not set."""
         monkeypatch.delenv("ENVIRONMENT_NAME", raising=False)
 
-        assert get_environment() == "local"
+        assert get_environment() == "development"
 
 
 class TestGetClientId:
     """Tests for get_client_id()."""
 
     def test_builds_client_id_from_environment(self, monkeypatch):
-        """Should combine environment and app into the EED client ID format."""
+        """Should combine environment into the EED client ID format."""
         monkeypatch.setenv("ENVIRONMENT_NAME", "uat")
 
         assert get_client_id() == "eed-uat-mcp"
 
-    def test_uses_custom_app_name(self, monkeypatch):
-        """Should accept a custom app suffix."""
+    def test_returns_prod_client_id(self, monkeypatch):
+        """Should return the correct production client ID."""
         monkeypatch.setenv("ENVIRONMENT_NAME", "prod")
 
-        assert get_client_id(app="ingest") == "eed-prod-ingest"
+        assert get_client_id() == "eed-prod-mcp"
 
-    def test_defaults_app_to_mcp(self, monkeypatch):
-        """Default app name should be 'mcp'."""
-        monkeypatch.setenv("ENVIRONMENT_NAME", "sit")
-
-        assert get_client_id() == "eed-sit-mcp"
-
-    def test_defaults_to_local_when_environment_unset(self, monkeypatch):
-        """Should use 'local' environment when ENVIRONMENT_NAME is not set."""
+    def test_defaults_to_development_when_environment_unset(self, monkeypatch):
+        """Should use 'development' environment when ENVIRONMENT_NAME is not set."""
         monkeypatch.delenv("ENVIRONMENT_NAME", raising=False)
 
-        assert get_client_id() == "eed-local-mcp"
+        assert get_client_id() == "eed-development-mcp"

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -1,0 +1,61 @@
+"""Tests for util.environment."""
+
+import pytest
+
+from util.environment import get_client_id, get_environment
+
+
+class TestGetEnvironment:
+    """Tests for get_environment()."""
+
+    def test_returns_environment_name_when_set(self, monkeypatch):
+        """Should return the value of ENVIRONMENT_NAME."""
+        monkeypatch.setenv("ENVIRONMENT_NAME", "uat")
+
+        assert get_environment() == "uat"
+
+    def test_returns_prod(self, monkeypatch):
+        """Should return prod for a production deployment."""
+        monkeypatch.setenv("ENVIRONMENT_NAME", "prod")
+
+        assert get_environment() == "prod"
+
+    def test_returns_test_for_ci(self, monkeypatch):
+        """Should return test when set by CI/CD pipeline."""
+        monkeypatch.setenv("ENVIRONMENT_NAME", "test")
+
+        assert get_environment() == "test"
+
+    def test_defaults_to_local_when_unset(self, monkeypatch):
+        """Should default to 'local' when ENVIRONMENT_NAME is not set."""
+        monkeypatch.delenv("ENVIRONMENT_NAME", raising=False)
+
+        assert get_environment() == "local"
+
+
+class TestGetClientId:
+    """Tests for get_client_id()."""
+
+    def test_builds_client_id_from_environment(self, monkeypatch):
+        """Should combine environment and app into the EED client ID format."""
+        monkeypatch.setenv("ENVIRONMENT_NAME", "uat")
+
+        assert get_client_id() == "eed-uat-mcp"
+
+    def test_uses_custom_app_name(self, monkeypatch):
+        """Should accept a custom app suffix."""
+        monkeypatch.setenv("ENVIRONMENT_NAME", "prod")
+
+        assert get_client_id(app="ingest") == "eed-prod-ingest"
+
+    def test_defaults_app_to_mcp(self, monkeypatch):
+        """Default app name should be 'mcp'."""
+        monkeypatch.setenv("ENVIRONMENT_NAME", "sit")
+
+        assert get_client_id() == "eed-sit-mcp"
+
+    def test_defaults_to_local_when_environment_unset(self, monkeypatch):
+        """Should use 'local' environment when ENVIRONMENT_NAME is not set."""
+        monkeypatch.delenv("ENVIRONMENT_NAME", raising=False)
+
+        assert get_client_id() == "eed-local-mcp"

--- a/tests/utils/test_natural_language_geocoder.py
+++ b/tests/utils/test_natural_language_geocoder.py
@@ -69,40 +69,79 @@ class TestNormalizeGeometryToWkt:
         with pytest.raises(ValueError, match="Expected Shapely geometry object"):
             _normalize_geometry_to_wkt("not a geometry")
 
-    def test_repairs_invalid_geometry_with_buffer(self):
-        """Test that invalid geometries are repaired using buffer(0)."""
+    def test_repairs_invalid_geometry_with_make_valid(self):
+        """Test that invalid geometries are repaired using make_valid()."""
         # Create a self-intersecting polygon (bow-tie shape)
         invalid_polygon = Polygon([(0, 0), (2, 2), (2, 0), (0, 2), (0, 0)])
 
-        # Should not raise, should repair with buffer(0)
+        # Should not raise, should repair with make_valid()
         result = _normalize_geometry_to_wkt(invalid_polygon)
 
         assert result is not None
-        assert result.startswith("POLYGON")
+        # make_valid() on a bow-tie produces a MultiPolygon (two triangles)
+        assert result.startswith("POLYGON") or result.startswith("MULTIPOLYGON")
 
     def test_raises_validation_error_for_unrepairable_geometry(self):
         """Test that geometries that can't be repaired raise ValueError."""
-        # Mock a geometry that is_valid returns False even after buffer
+        # Mock a geometry that is_valid returns False even after make_valid()
         mock_geom = MagicMock()
         mock_geom.geom_type = "Polygon"
         mock_geom.is_empty = False
         mock_geom.is_valid = False
-        mock_geom.buffer.return_value.is_empty = False
-        mock_geom.buffer.return_value.is_valid = False
 
-        with pytest.raises(ValueError, match="could not be repaired"):
-            _normalize_geometry_to_wkt(mock_geom)
+        with patch("util.natural_language_geocoder.make_valid") as mock_make_valid:
+            mock_make_valid.return_value.is_empty = False
+            mock_make_valid.return_value.is_valid = False
+            mock_make_valid.return_value.geom_type = "Polygon"
 
-    def test_raises_validation_error_when_buffer_raises_exception(self):
-        """Test that exceptions during buffer operation are caught."""
+            with pytest.raises(ValueError, match="could not be repaired"):
+                _normalize_geometry_to_wkt(mock_geom)
+
+    def test_raises_validation_error_when_make_valid_raises_exception(self):
+        """Test that exceptions during make_valid() are caught."""
         mock_geom = MagicMock()
         mock_geom.geom_type = "Polygon"
         mock_geom.is_empty = False
         mock_geom.is_valid = False
-        mock_geom.buffer.side_effect = Exception("Buffer failed")
 
-        with pytest.raises(ValueError, match="Invalid geometry"):
-            _normalize_geometry_to_wkt(mock_geom)
+        with patch(
+            "util.natural_language_geocoder.make_valid", side_effect=Exception("make_valid failed")
+        ):
+            with pytest.raises(ValueError, match="Invalid geometry"):
+                _normalize_geometry_to_wkt(mock_geom)
+
+    def test_valid_geometry_skips_make_valid(self):
+        """Test that make_valid() is never called when geometry is already valid."""
+        valid_polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+        assert valid_polygon.is_valid
+
+        with patch("util.natural_language_geocoder.make_valid") as mock_make_valid:
+            _normalize_geometry_to_wkt(valid_polygon)
+
+        mock_make_valid.assert_not_called()
+
+    def test_repair_emits_warning_log(self, caplog):
+        """Test that repairing an invalid geometry emits a WARNING log."""
+        invalid_polygon = Polygon([(0, 0), (2, 2), (2, 0), (0, 2), (0, 0)])
+        assert not invalid_polygon.is_valid
+
+        with caplog.at_level("WARNING"):
+            _normalize_geometry_to_wkt(invalid_polygon)
+
+        assert any("make_valid" in record.message for record in caplog.records)
+
+    def test_raises_when_make_valid_returns_empty_geometry(self):
+        """Test that a ValueError is raised when make_valid() produces an empty geometry."""
+        mock_geom = MagicMock()
+        mock_geom.geom_type = "Polygon"
+        mock_geom.is_empty = False
+        mock_geom.is_valid = False
+
+        with patch("util.natural_language_geocoder.make_valid") as mock_make_valid:
+            mock_make_valid.return_value.is_empty = True
+
+            with pytest.raises(ValueError, match="empty after make_valid"):
+                _normalize_geometry_to_wkt(mock_geom)
 
     def test_invalid_polygon_repaired_and_exterior_is_ccw(self):
         """Test that an invalid self-intersecting polygon is repaired and reoriented counter-clockwise."""
@@ -116,7 +155,7 @@ class TestNormalizeGeometryToWkt:
         from shapely import wkt as shapely_wkt
 
         repaired = shapely_wkt.loads(result)
-        # buffer(0) on a bow-tie typically produces a MultiPolygon
+        # make_valid() on a bow-tie typically produces a MultiPolygon
         if repaired.geom_type == "MultiPolygon":
             for part in repaired.geoms:
                 assert LinearRing(

--- a/tests/utils/test_natural_language_geocoder.py
+++ b/tests/utils/test_natural_language_geocoder.py
@@ -21,12 +21,12 @@ class TestNormalizeGeometryToWkt:
         assert result.startswith("POLYGON")
         assert "0 0" in result
 
-    def test_orients_polygon_counter_clockwise(self):
-        """Test that polygons are oriented counter-clockwise (exterior ring CCW)."""
-        # Create a clockwise polygon (CMR requires counter-clockwise)
-        clockwise_polygon = Polygon([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])
+    def test_orients_polygon_exterior_to_ccw(self):
+        """Test that polygons are oriented counter-clockwise (exterior ring counter-clockwise)."""
+        # Create a CW polygon (CMR requires CCW)
+        cw_polygon = Polygon([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])
 
-        result = _normalize_geometry_to_wkt(clockwise_polygon)
+        result = _normalize_geometry_to_wkt(cw_polygon)
 
         assert result is not None
         from shapely import wkt
@@ -34,9 +34,9 @@ class TestNormalizeGeometryToWkt:
         result_geom = wkt.loads(result)
         assert LinearRing(result_geom.exterior.coords).is_ccw
 
-    def test_preserves_counter_clockwise_orientation(self):
+    def test_preserves_ccw_polygon_orientation(self):
         """Test that counter-clockwise polygons remain counter-clockwise."""
-        # Create a counter-clockwise polygon
+        # Create a CCW polygon
         ccw_polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
 
         result = _normalize_geometry_to_wkt(ccw_polygon)
@@ -104,8 +104,126 @@ class TestNormalizeGeometryToWkt:
         with pytest.raises(ValueError, match="Invalid geometry"):
             _normalize_geometry_to_wkt(mock_geom)
 
+    def test_invalid_polygon_repaired_and_exterior_is_ccw(self):
+        """Test that an invalid self-intersecting polygon is repaired and reoriented counter-clockwise."""
+        # Bow-tie shape — self-intersecting, invalid
+        invalid_polygon = Polygon([(0, 0), (2, 2), (2, 0), (0, 2), (0, 0)])
+        assert not invalid_polygon.is_valid
 
-class TestConvertTextToGeom:
+        result = _normalize_geometry_to_wkt(invalid_polygon)
+
+        assert result is not None
+        from shapely import wkt as shapely_wkt
+
+        repaired = shapely_wkt.loads(result)
+        # buffer(0) on a bow-tie typically produces a MultiPolygon
+        if repaired.geom_type == "MultiPolygon":
+            for part in repaired.geoms:
+                assert LinearRing(
+                    part.exterior.coords
+                ).is_ccw, f"Exterior ring of repaired part is not CCW: {part}"
+        else:
+            assert LinearRing(repaired.exterior.coords).is_ccw
+
+    def test_orients_cw_multipolygon_exterior_to_ccw(self):
+        """Test that a MultiPolygon with clockwise exterior rings is reoriented to counter-clockwise."""
+        # Explicitly CW polygons
+        cw_poly1 = Polygon([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])
+        cw_poly2 = Polygon([(2, 0), (2, 1), (3, 1), (3, 0), (2, 0)])
+        assert not LinearRing(cw_poly1.exterior.coords).is_ccw
+        assert not LinearRing(cw_poly2.exterior.coords).is_ccw
+
+        result = _normalize_geometry_to_wkt(MultiPolygon([cw_poly1, cw_poly2]))
+
+        assert result is not None
+        from shapely import wkt as shapely_wkt
+
+        oriented = shapely_wkt.loads(result)
+        assert oriented.geom_type == "MULTIPOLYGON" or oriented.geom_type == "MultiPolygon"
+        for part in oriented.geoms:
+            assert LinearRing(
+                part.exterior.coords
+            ).is_ccw, f"Exterior ring of MultiPolygon part is not CCW: {part}"
+
+    def test_preserves_ccw_multipolygon_orientation(self):
+        """Test that a MultiPolygon already counter-clockwise stays counter-clockwise after normalization."""
+        ccw_poly1 = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+        ccw_poly2 = Polygon([(2, 0), (3, 0), (3, 1), (2, 1), (2, 0)])
+
+        result = _normalize_geometry_to_wkt(MultiPolygon([ccw_poly1, ccw_poly2]))
+
+        assert result is not None
+        from shapely import wkt as shapely_wkt
+
+        oriented = shapely_wkt.loads(result)
+        for part in oriented.geoms:
+            assert LinearRing(part.exterior.coords).is_ccw
+
+    def test_polygon_with_hole_exterior_ccw_and_hole_cw(self):
+        """Test that a Polygon with a hole has counter-clockwise exterior and clockwise interior ring."""
+        exterior = [(0, 0), (10, 0), (10, 10), (0, 10), (0, 0)]
+        # Interior ring (hole) — deliberately CCW so orient_polygons must flip it to CW
+        hole = [(2, 2), (4, 2), (4, 4), (2, 4), (2, 2)]
+        polygon_with_hole = Polygon(exterior, [hole])
+
+        result = _normalize_geometry_to_wkt(polygon_with_hole)
+
+        assert result is not None
+        from shapely import wkt as shapely_wkt
+
+        oriented = shapely_wkt.loads(result)
+        assert LinearRing(oriented.exterior.coords).is_ccw, "Exterior ring should be CCW"
+        for interior in oriented.interiors:
+            assert not LinearRing(interior.coords).is_ccw, "Interior ring (hole) should be CW"
+
+    def test_polygon_with_cw_exterior_and_ccw_hole_both_reoriented(self):
+        """Test that a Polygon with a clockwise exterior and counter-clockwise hole has both rings reoriented."""
+        # CW exterior — needs flipping to CCW
+        cw_exterior = [(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)]
+        # CCW hole — needs flipping to CW
+        ccw_hole = [(2, 2), (4, 2), (4, 4), (2, 4), (2, 2)]
+        assert not LinearRing(cw_exterior).is_ccw
+        assert LinearRing(ccw_hole).is_ccw
+        polygon_with_hole = Polygon(cw_exterior, [ccw_hole])
+
+        result = _normalize_geometry_to_wkt(polygon_with_hole)
+
+        assert result is not None
+        from shapely import wkt as shapely_wkt
+
+        oriented = shapely_wkt.loads(result)
+        assert LinearRing(oriented.exterior.coords).is_ccw, "Exterior ring should be CCW"
+        for interior in oriented.interiors:
+            assert not LinearRing(interior.coords).is_ccw, "Interior ring (hole) should be CW"
+
+    def test_multipolygon_with_holes_exterior_ccw_and_holes_cw(self):
+        """Test that each part of a MultiPolygon with holes has counter-clockwise exterior and clockwise holes."""
+        exterior1 = [(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)]  # CW exterior
+        hole1 = [(2, 2), (4, 2), (4, 4), (2, 4), (2, 2)]  # CCW hole
+        exterior2 = [(20, 0), (20, 10), (30, 10), (30, 0), (20, 0)]  # CW exterior
+        hole2 = [(22, 2), (24, 2), (24, 4), (22, 4), (22, 2)]  # CCW hole
+        mp = MultiPolygon(
+            [
+                Polygon(exterior1, [hole1]),
+                Polygon(exterior2, [hole2]),
+            ]
+        )
+
+        result = _normalize_geometry_to_wkt(mp)
+
+        assert result is not None
+        from shapely import wkt as shapely_wkt
+
+        oriented = shapely_wkt.loads(result)
+        for part in oriented.geoms:
+            assert LinearRing(
+                part.exterior.coords
+            ).is_ccw, f"Exterior ring of part is not CCW: {part}"
+            for interior in part.interiors:
+                assert not LinearRing(
+                    interior.coords
+                ).is_ccw, f"Interior ring (hole) of part is not CW: {interior}"
+
     """Tests for convert_text_to_geom function."""
 
     @patch("util.natural_language_geocoder.extract_geometry_from_text")

--- a/tests/utils/test_natural_language_geocoder.py
+++ b/tests/utils/test_natural_language_geocoder.py
@@ -21,6 +21,34 @@ class TestNormalizeGeometryToWkt:
         assert result.startswith("POLYGON")
         assert "0 0" in result
 
+    def test_orients_polygon_counter_clockwise(self):
+        """Test that polygons are oriented counter-clockwise (exterior ring CCW)."""
+        # Create a clockwise polygon (CMR requires counter-clockwise)
+        clockwise_polygon = Polygon([(0, 0), (0, 1), (1, 1), (1, 0), (0, 0)])
+
+        result = _normalize_geometry_to_wkt(clockwise_polygon)
+
+        assert result is not None
+        # Parse result to verify orientation
+        from shapely import wkt
+
+        result_geom = wkt.loads(result)
+        # Exterior ring with positive area means counter-clockwise
+        assert LinearRing(result_geom.exterior.coords).is_ccw
+
+    def test_preserves_counter_clockwise_orientation(self):
+        """Test that counter-clockwise polygons remain counter-clockwise."""
+        # Create a counter-clockwise polygon
+        ccw_polygon = Polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+
+        result = _normalize_geometry_to_wkt(ccw_polygon)
+
+        assert result is not None
+        from shapely import wkt
+
+        result_geom = wkt.loads(result)
+        assert LinearRing(result_geom.exterior.coords).is_ccw
+
     def test_converts_point_to_wkt(self):
         """Test Point geometry conversion."""
         point = Point(10.5, 20.3)

--- a/tests/utils/test_natural_language_geocoder.py
+++ b/tests/utils/test_natural_language_geocoder.py
@@ -29,11 +29,9 @@ class TestNormalizeGeometryToWkt:
         result = _normalize_geometry_to_wkt(clockwise_polygon)
 
         assert result is not None
-        # Parse result to verify orientation
         from shapely import wkt
 
         result_geom = wkt.loads(result)
-        # Exterior ring with positive area means counter-clockwise
         assert LinearRing(result_geom.exterior.coords).is_ccw
 
     def test_preserves_counter_clockwise_orientation(self):

--- a/tools/discover_data/tool.py
+++ b/tools/discover_data/tool.py
@@ -135,7 +135,6 @@ def discover_data(params: DiscoverDataInput) -> dict:  # pylint: disable=too-man
             spatial.wkt_geometry,
         )
 
-        # Track if granule validation removed ALL collections
         all_filtered_by_granule_validation = (
             collections_before_granule_validation > 0 and not collections
         )

--- a/tools/discover_data/tool.py
+++ b/tools/discover_data/tool.py
@@ -126,22 +126,21 @@ def discover_data(params: DiscoverDataInput) -> dict:  # pylint: disable=too-man
         trace_update(metadata={"hydrated_collections_count": len(collections)})
 
         # === PHASE 4.5: Granule Validation ===
-        all_filtered_by_granule_validation = False
-        if collections:
-            collections_before_granule_validation = len(collections)
+        collections_before_granule_validation = len(collections)
 
-            collections = validate_granule_availability(
-                collections,
-                temporal.start_date,
-                temporal.end_date,
-                spatial.wkt_geometry,
-            )
+        collections = validate_granule_availability(
+            collections,
+            temporal.start_date,
+            temporal.end_date,
+            spatial.wkt_geometry,
+        )
 
-            # Explicitly track if granule validation removed ALL collections
-            all_filtered_by_granule_validation = (
-                collections_before_granule_validation > 0 and not collections
-            )
+        # Track if granule validation removed ALL collections
+        all_filtered_by_granule_validation = (
+            collections_before_granule_validation > 0 and not collections
+        )
 
+        if collections_before_granule_validation != len(collections):
             trace_update(
                 metadata={
                     "collections_before_granule_validation": collections_before_granule_validation,

--- a/tools/discover_data/tool.py
+++ b/tools/discover_data/tool.py
@@ -21,7 +21,10 @@ from tools.discover_data.utils.disambiguation import (
     filter_by_user_refinements,
 )
 from tools.discover_data.utils.embedding_search import search_all_entity_types
-from tools.discover_data.utils.granule_availability import validate_granule_availability
+from tools.discover_data.utils.granule_availability import (
+    GranuleValidationError,
+    validate_granule_availability,
+)
 from tools.discover_data.utils.query_expansion import (
     analyze_embedding_results,
     generate_expansion_questions,
@@ -206,8 +209,24 @@ def discover_data(params: DiscoverDataInput) -> dict:  # pylint: disable=too-man
 
         return output.model_dump()
 
+    except GranuleValidationError:
+        logger.warning("Granule availability check failed", exc_info=True)
+
+        trace_update(
+            tags=["error"],
+            metadata={"error_type": "GranuleValidationError"},
+        )
+
+        return DiscoverDataOutput(
+            status=DiscoveryStatus.ERROR,
+            error_message=(
+                "Granule availability check failed due to a service error. "
+                "Please try your request again."
+            ),
+        ).model_dump()
+
     except Exception as e:
-        logger.exception("Error in discover_data")
+        logger.exception("Error in discover_data: %s", e)
 
         trace_update(
             tags=["error"],
@@ -219,7 +238,7 @@ def discover_data(params: DiscoverDataInput) -> dict:  # pylint: disable=too-man
 
         return DiscoverDataOutput(
             status=DiscoveryStatus.ERROR,
-            error_message=str(e),
+            error_message="An unexpected error occurred. Please try your request again.",
         ).model_dump()
 
 

--- a/tools/discover_data/tool.py
+++ b/tools/discover_data/tool.py
@@ -139,7 +139,7 @@ def discover_data(params: DiscoverDataInput) -> dict:  # pylint: disable=too-man
 
             # Explicitly track if granule validation removed ALL collections
             all_filtered_by_granule_validation = (
-                collections_before_granule_validation > 0 and len(collections) == 0
+                collections_before_granule_validation > 0 and not collections
             )
 
             trace_update(

--- a/tools/discover_data/tool.py
+++ b/tools/discover_data/tool.py
@@ -21,6 +21,7 @@ from tools.discover_data.utils.disambiguation import (
     filter_by_user_refinements,
 )
 from tools.discover_data.utils.embedding_search import search_all_entity_types
+from tools.discover_data.utils.granule_availability import validate_granule_availability
 from tools.discover_data.utils.query_expansion import (
     analyze_embedding_results,
     generate_expansion_questions,
@@ -49,8 +50,9 @@ def discover_data(params: DiscoverDataInput) -> dict:  # pylint: disable=too-man
     2. PHASE 2: Searches ALL entity types (collections, variables, instruments, etc.)
     3. PHASE 3: Scores collections based on direct matches + indirect signals
     4. PHASE 4: Hydrates collections and applies temporal/spatial filtering
-    5. PHASE 5: Applies user refinements and checks for query expansion or disambiguation
-    6. PHASE 6: Returns ranked results with clarifying questions if needed
+    5. PHASE 4.5: Validates granule availability for filtered collections
+    6. PHASE 5: Applies user refinements and checks for query expansion or disambiguation
+    7. PHASE 6: Returns ranked results with clarifying questions if needed
 
     Args:
         params: Natural language query with optional constraints and context
@@ -123,6 +125,33 @@ def discover_data(params: DiscoverDataInput) -> dict:  # pylint: disable=too-man
 
         trace_update(metadata={"hydrated_collections_count": len(collections)})
 
+        # === PHASE 4.5: Granule Validation ===
+        all_filtered_by_granule_validation = False
+        if collections:
+            collections_before_granule_validation = len(collections)
+
+            collections = validate_granule_availability(
+                collections,
+                temporal.start_date,
+                temporal.end_date,
+                spatial.wkt_geometry,
+            )
+
+            # Explicitly track if granule validation removed ALL collections
+            all_filtered_by_granule_validation = (
+                collections_before_granule_validation > 0 and len(collections) == 0
+            )
+
+            trace_update(
+                metadata={
+                    "collections_before_granule_validation": collections_before_granule_validation,
+                    "collections_after_granule_validation": len(collections),
+                    "filtered_by_granule_check": (
+                        collections_before_granule_validation - len(collections)
+                    ),
+                }
+            )
+
         # Apply user refinements from search context (disambiguation answers)
         if params.search_context and params.search_context.user_refinements:
             collections = filter_by_user_refinements(
@@ -147,6 +176,7 @@ def discover_data(params: DiscoverDataInput) -> dict:  # pylint: disable=too-man
                 collections,
                 needs_disambiguation,
                 scored_collections,
+                all_filtered_by_granule_validation=all_filtered_by_granule_validation,
             )
 
         # === PHASE 6: Output Assembly ===
@@ -214,21 +244,23 @@ def _extract_or_use_constraints(
 
 
 def _determine_status(
-    filtered_collections: list[CollectionMatch],
+    collections: list[CollectionMatch],
     needs_disambiguation: bool,
     _ranked_results: list[dict],
+    all_filtered_by_granule_validation: bool = False,
 ) -> DiscoveryStatus:
     """Determine the appropriate discovery status."""
-    if not filtered_collections:
+    if all_filtered_by_granule_validation:
+        return DiscoveryStatus.NO_GRANULES_IN_CONSTRAINTS
+
+    if not collections:
         return DiscoveryStatus.NO_RESULTS
 
     if needs_disambiguation:
         return DiscoveryStatus.DISAMBIGUATION_NEEDED
 
     # Check if any results are indirect matches
-    has_indirect = any(
-        c.match_type not in ("direct", "direct_and_indirect") for c in filtered_collections
-    )
+    has_indirect = any(c.match_type not in ("direct", "direct_and_indirect") for c in collections)
     if has_indirect:
         return DiscoveryStatus.INDIRECT_MATCHES
 

--- a/tools/discover_data/utils/collection_hydration.py
+++ b/tools/discover_data/utils/collection_hydration.py
@@ -96,6 +96,9 @@ def hydrate_collections(
         title = metadata.get("EntryTitle") or result.get("text_content", "")
         abstract = metadata.get("Abstract")
 
+        # Extract is_ongoing from temporal_coverage if available
+        is_ongoing = temporal_coverage.is_ongoing if temporal_coverage else False
+
         match = CollectionMatch(
             concept_id=concept_id,
             title=title,
@@ -109,6 +112,7 @@ def hydrate_collections(
             instruments=instruments,
             related_entity_id=result.get("related_entity_id"),
             related_entity_text=result.get("related_entity_text"),
+            is_ongoing=is_ongoing,
         )
         matches.append(match)
 

--- a/tools/discover_data/utils/collection_hydration.py
+++ b/tools/discover_data/utils/collection_hydration.py
@@ -36,8 +36,7 @@ def hydrate_collections(
     Fetches metadata from the collections table and uses resolution parsing
     to populate resolution, temporal_coverage, platforms, and instruments.
 
-    Applies temporal and spatial filtering at the database level using the
-    provided temporal and spatial constraints.
+    Applies temporal and spatial filtering at the database level.
 
     Args:
         ranked_results: Scored collection results from embedding search/scoring

--- a/tools/discover_data/utils/collection_hydration.py
+++ b/tools/discover_data/utils/collection_hydration.py
@@ -36,7 +36,8 @@ def hydrate_collections(
     Fetches metadata from the collections table and uses resolution parsing
     to populate resolution, temporal_coverage, platforms, and instruments.
 
-    Applies temporal and spatial filtering at the database level.
+    Applies temporal and spatial filtering at the database level using the
+    provided temporal and spatial constraints.
 
     Args:
         ranked_results: Scored collection results from embedding search/scoring
@@ -45,7 +46,7 @@ def hydrate_collections(
         spatial_wkt: Optional WKT geometry - exclude collections that don't intersect
 
     Returns:
-        List of fully hydrated CollectionMatch objects (filtered by constraints)
+        List of hydrated CollectionMatch objects that pass temporal/spatial filters
     """
     # Filter to collection results only
     collection_results = [r for r in ranked_results if r.get("type") == "collection"]

--- a/tools/discover_data/utils/granule_availability.py
+++ b/tools/discover_data/utils/granule_availability.py
@@ -172,8 +172,7 @@ def validate_granule_availability(
 
             cached_result = cache.get(cache_key)
             if cached_result:
-                cached_data = json.loads(cached_result)
-                collection.granule_count = cached_data["count"]
+                collection.granule_count = cached_result["count"]
             else:
                 task = executor.submit(
                     _count_granules,
@@ -199,7 +198,7 @@ def validate_granule_availability(
                 ttl = _get_cache_ttl(collection.is_ongoing)
                 cache.set(
                     cache_key,
-                    json.dumps({"count": hits_count, "timestamp": time.time()}),
+                    {"count": hits_count, "timestamp": time.time()},
                     ttl=ttl,
                 )
 

--- a/tools/discover_data/utils/granule_availability.py
+++ b/tools/discover_data/utils/granule_availability.py
@@ -24,6 +24,11 @@ from util.cmr.client import search_cmr
 
 logger = logging.getLogger(__name__)
 
+
+class GranuleValidationError(Exception):
+    """Raised when one or more collections fail CMR granule validation."""
+
+
 GRANULE_VALIDATION_MAX_WORKERS = int(os.environ.get("GRANULE_VALIDATION_MAX_WORKERS", "10"))
 
 
@@ -213,14 +218,16 @@ def validate_granule_availability(
                     exc_info=True,
                 )
                 failures += 1
-                collection.granule_count = None
+
+    if failures > 0:
+        raise GranuleValidationError(
+            f"CMR granule validation failed for {failures} of "
+            f"{len(pending_validations)} collection(s)"
+        )
 
     validated = []
     for collection in collections:
-        if collection.granule_count is None:
-            # CMR failure — keep rather than silently drop
-            validated.append(collection)
-        elif collection.granule_count > 0:
+        if collection.granule_count > 0:
             validated.append(collection)
         else:
             zero_granule_count += 1

--- a/tools/discover_data/utils/granule_availability.py
+++ b/tools/discover_data/utils/granule_availability.py
@@ -75,18 +75,22 @@ def _count_granules(
         files = {"shapefile": ("shapefile", file_obj, "application/geo+json")}
 
     # page_size=0: CMR only populates total_hits, not items — one response page is all we need
-    for page in search_cmr(
-        concept_type="granule",
-        search_params=params,
-        page_size=0,
-        method="POST",
-        files=files,
-    ):
-        return page.total_hits, page.took_ms
+    page = next(
+        search_cmr(
+            concept_type="granule",
+            search_params=params,
+            page_size=0,
+            method="POST",
+            files=files,
+        ),
+        None,
+    )
 
-    # If no pages returned (shouldn't happen), return 0
-    logger.warning("No response from CMR for %s", collection_concept_id)
-    return 0, 0
+    if page is None:
+        logger.warning("No response from CMR for %s", collection_concept_id)
+        return 0, 0
+
+    return page.total_hits, page.took_ms
 
 
 def _build_cache_key(

--- a/tools/discover_data/utils/granule_availability.py
+++ b/tools/discover_data/utils/granule_availability.py
@@ -151,6 +151,14 @@ def validate_granule_availability(
     Returns:
         list[CollectionMatch] with granule_count > 0
     """
+    # Only validate if constraints exist - without them, assume exploratory search
+    if not temporal_start and not spatial_wkt:
+        logger.info("Skipping granule validation - no spatial or temporal constraints")
+        return collections
+
+    if not collections:
+        return collections
+
     cache = get_cache_client()
 
     failures = 0

--- a/tools/discover_data/utils/granule_availability.py
+++ b/tools/discover_data/utils/granule_availability.py
@@ -24,7 +24,7 @@ from util.cmr.client import CMRError, search_cmr
 
 logger = logging.getLogger(__name__)
 
-GRANULE_VALIDATION_MAX_WORKERS = int(os.environ.get("GRANULE_VALIDATION_MAX_WORKERS", "5"))
+GRANULE_VALIDATION_MAX_WORKERS = int(os.environ.get("GRANULE_VALIDATION_MAX_WORKERS", "10"))
 
 
 @observe(name="count_granules")
@@ -129,32 +129,6 @@ def _get_cache_ttl(is_ongoing: bool) -> int:
     return 900 if is_ongoing else 86400
 
 
-def _validate_single_collection(
-    collection: CollectionMatch,
-    temporal_start: datetime | None,
-    temporal_end: datetime | None,
-    spatial_wkt: str | None,
-) -> tuple[int, int]:
-    """
-    Validate a single collection by counting its granules.
-
-    Args:
-        collection: Collection to validate
-        temporal_start: Optional start datetime
-        temporal_end: Optional end datetime
-        spatial_wkt: Optional WKT geometry string
-
-    Returns:
-        Tuple of (hits_count, took_ms)
-    """
-    return _count_granules(
-        collection.concept_id,
-        temporal_start,
-        temporal_end,
-        spatial_wkt,
-    )
-
-
 @observe(name="validate_granule_availability")
 def validate_granule_availability(
     collections: list[CollectionMatch],
@@ -200,51 +174,45 @@ def validate_granule_availability(
             else:
                 # Submit for parallel validation
                 task = executor.submit(
-                    _validate_single_collection,
-                    collection,
+                    _count_granules,
+                    collection.concept_id,
                     temporal_start,
                     temporal_end,
                     spatial_wkt,
                 )
                 pending_validations[task] = collection
 
-        # Process results as they complete (scale timeout with collection count)
-        timeout = max(60, len(pending_validations) * 2)
-        try:
-            for task in as_completed(pending_validations, timeout=timeout):
-                collection = pending_validations[task]
-                try:
-                    hits_count, _ = task.result()
-                    collection.granule_count = hits_count
+        for task in as_completed(pending_validations):
+            collection = pending_validations[task]
+            try:
+                hits_count, _ = task.result()
+                collection.granule_count = hits_count
 
-                    # Cache the result
-                    cache_key = _build_cache_key(
-                        collection.concept_id,
-                        temporal_start,
-                        temporal_end,
-                        spatial_wkt,
-                    )
-                    ttl = _get_cache_ttl(collection.is_ongoing)
-                    cache.set(
-                        cache_key,
-                        json.dumps({"count": hits_count, "timestamp": time.time()}),
-                        ttl=ttl,
-                    )
+                # Cache the result
+                cache_key = _build_cache_key(
+                    collection.concept_id,
+                    temporal_start,
+                    temporal_end,
+                    spatial_wkt,
+                )
+                ttl = _get_cache_ttl(collection.is_ongoing)
+                cache.set(
+                    cache_key,
+                    json.dumps({"count": hits_count, "timestamp": time.time()}),
+                    ttl=ttl,
+                )
 
-                except Exception as e:
-                    logger.warning(
-                        "Granule validation failed for %s: %s (type: %s)",
-                        collection.concept_id,
-                        e,
-                        type(e).__name__,
-                        exc_info=True,
-                    )
-                    failures += 1
-                    # Keep collection with None granule_count
-                    collection.granule_count = None
-
-        except TimeoutError:
-            logger.warning("Granule availability check timed out for some collections")
+            except Exception as e:
+                logger.warning(
+                    "Granule validation failed for %s: %s (type: %s)",
+                    collection.concept_id,
+                    e,
+                    type(e).__name__,
+                    exc_info=True,
+                )
+                failures += 1
+                # Keep collection with None granule_count
+                collection.granule_count = None
             failures += len(pending_validations)
 
     # Filter out collections with zero granules

--- a/tools/discover_data/utils/granule_availability.py
+++ b/tools/discover_data/utils/granule_availability.py
@@ -10,7 +10,7 @@ import json
 import logging
 import os
 import time
-from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from io import BytesIO
 
@@ -79,7 +79,7 @@ def _count_granules(
             concept_type="granule",
             search_params=params,
             page_size=0,
-            method="POST" if files else "GET",
+            method="POST",
             files=files,
         ):
             return page.total_hits, page.took_ms
@@ -214,7 +214,7 @@ def validate_granule_availability(
             for task in as_completed(pending_validations, timeout=timeout):
                 collection = pending_validations[task]
                 try:
-                    hits_count, took_ms = task.result()
+                    hits_count, _ = task.result()
                     collection.granule_count = hits_count
 
                     # Cache the result
@@ -252,12 +252,13 @@ def validate_granule_availability(
     for collection in collections:
         if collection.granule_count is not None and collection.granule_count > 0:
             validated.append(collection)
-        elif collection.granule_count == 0:
+        elif not collection.granule_count:
             zero_granule_count += 1
 
     if zero_granule_count > 0 or failures > 0:
         logger.info(
-            "Granule availability: %d/%d collections validated (filtered %d with no granules, %d failures)",
+            "Granule availability: %d/%d collections validated "
+            "(filtered %d with no granules, %d failures)",
             len(validated),
             len(collections),
             zero_granule_count,

--- a/tools/discover_data/utils/granule_availability.py
+++ b/tools/discover_data/utils/granule_availability.py
@@ -1,0 +1,268 @@
+"""
+Granule availability validation utilities for discover_data orchestrator.
+
+Validates collections by checking for actual granule data within spatio-temporal
+constraints using CMR's granule endpoint.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
+from datetime import datetime
+from io import BytesIO
+
+from langfuse import observe
+from shapely import wkt as shapely_wkt
+from shapely.geometry import mapping
+
+from tools.models.output_model import CollectionMatch
+from util.cache import get_cache_client
+from util.cmr.client import CMRError, search_cmr
+
+logger = logging.getLogger(__name__)
+
+GRANULE_VALIDATION_MAX_WORKERS = int(os.environ.get("GRANULE_VALIDATION_MAX_WORKERS", "5"))
+
+
+@observe(name="count_granules")
+def _count_granules(
+    collection_concept_id: str,
+    temporal_start: datetime | None = None,
+    temporal_end: datetime | None = None,
+    spatial_wkt: str | None = None,
+) -> tuple[int, int]:
+    """
+    Count granules for a collection with optional temporal/spatial constraints.
+
+    Args:
+        collection_concept_id: CMR collection concept ID
+        temporal_start: Optional start datetime for temporal constraint
+        temporal_end: Optional end datetime for temporal constraint
+        spatial_wkt: Optional WKT geometry string for spatial constraint
+
+    Returns:
+        Tuple of (hits_count, took_ms) where:
+        - hits_count: Number of granules matching constraints
+        - took_ms: Time taken by CMR (from CMR-Took header)
+
+    Raises:
+        CMRError: If the request fails
+    """
+    params = {"collection_concept_id": collection_concept_id, "page_size": 0}
+
+    # Add temporal constraint if provided
+    if temporal_start is not None and temporal_end is not None:
+        params["temporal"] = f"{temporal_start.isoformat()}Z,{temporal_end.isoformat()}Z"
+
+    # Prepare shapefile if spatial constraint provided
+    files = None
+    if spatial_wkt:
+        geom = shapely_wkt.loads(spatial_wkt)
+        geojson = {
+            "type": "FeatureCollection",
+            "features": [{"type": "Feature", "geometry": mapping(geom), "properties": {}}],
+        }
+        file_obj = BytesIO(json.dumps(geojson).encode("utf-8"))
+        files = {"shapefile": ("shapefile", file_obj, "application/geo+json")}
+
+    # Use search_cmr to make the request
+    try:
+        # Get first (and only) page - we only need the count, not the items
+        for page in search_cmr(
+            concept_type="granule",
+            search_params=params,
+            page_size=0,
+            method="POST" if files else "GET",
+            files=files,
+        ):
+            return page.total_hits, page.took_ms
+
+        # If no pages returned (shouldn't happen), return 0
+        logger.warning("No response from CMR for %s", collection_concept_id)
+        return 0, 0
+
+    except CMRError as e:
+        logger.error(
+            "CMR granule count failed for %s: %s",
+            collection_concept_id,
+            e,
+        )
+        raise
+
+
+def _build_cache_key(
+    concept_id: str,
+    temporal_start: datetime | None,
+    temporal_end: datetime | None,
+    spatial_wkt: str | None,
+) -> str:
+    """
+    Build cache key for granule count result.
+
+    Args:
+        concept_id: CMR collection concept ID
+        temporal_start: Optional start datetime
+        temporal_end: Optional end datetime
+        spatial_wkt: Optional WKT geometry string
+
+    Returns:
+        Cache key string
+    """
+    constraint_str = f"{temporal_start}|{temporal_end}|{spatial_wkt}"
+    constraint_hash = hashlib.sha256(constraint_str.encode()).hexdigest()
+    return f"granule_count:{concept_id}:{constraint_hash}"
+
+
+def _get_cache_ttl(is_ongoing: bool) -> int:
+    """
+    Determine cache TTL based on whether collection is ongoing.
+
+    Args:
+        is_ongoing: Whether the collection is still actively collecting data
+
+    Returns:
+        TTL in seconds (900 for ongoing, 86400 for completed)
+    """
+    return 900 if is_ongoing else 86400
+
+
+def _validate_single_collection(
+    collection: CollectionMatch,
+    temporal_start: datetime | None,
+    temporal_end: datetime | None,
+    spatial_wkt: str | None,
+) -> tuple[int, int]:
+    """
+    Validate a single collection by counting its granules.
+
+    Args:
+        collection: Collection to validate
+        temporal_start: Optional start datetime
+        temporal_end: Optional end datetime
+        spatial_wkt: Optional WKT geometry string
+
+    Returns:
+        Tuple of (hits_count, took_ms)
+    """
+    return _count_granules(
+        collection.concept_id,
+        temporal_start,
+        temporal_end,
+        spatial_wkt,
+    )
+
+
+@observe(name="validate_granule_availability")
+def validate_granule_availability(
+    collections: list[CollectionMatch],
+    temporal_start: datetime | None,
+    temporal_end: datetime | None,
+    spatial_wkt: str | None,
+) -> list[CollectionMatch]:
+    """
+    Validate granule availability for collections with spatio-temporal constraints.
+
+    Checks each collection for granules within the constraints. Collections with zero granules
+    are filtered out. Results are cached with TTL based on whether collections are ongoing.
+
+    Args:
+        collections: List of collections to validate
+        temporal_start: Optional start datetime for temporal constraint
+        temporal_end: Optional end datetime for temporal constraint
+        spatial_wkt: Optional WKT geometry string for spatial constraint
+
+    Returns:
+        list[CollectionMatch] with granule_count > 0
+    """
+    cache = get_cache_client()
+
+    failures = 0
+    zero_granule_count = 0
+
+    # Check cache first for all collections
+    futures_to_collection = {}
+    with ThreadPoolExecutor(max_workers=GRANULE_VALIDATION_MAX_WORKERS) as executor:
+        for collection in collections:
+            cache_key = _build_cache_key(
+                collection.concept_id,
+                temporal_start,
+                temporal_end,
+                spatial_wkt,
+            )
+
+            # Try cache first
+            cached_result = cache.get(cache_key)
+            if cached_result:
+                cached_data = json.loads(cached_result)
+                collection.granule_count = cached_data["count"]
+            else:
+                # Submit for parallel validation
+                future = executor.submit(
+                    _validate_single_collection,
+                    collection,
+                    temporal_start,
+                    temporal_end,
+                    spatial_wkt,
+                )
+                futures_to_collection[future] = collection
+
+        # Process results as they complete (scale timeout with collection count)
+        timeout = max(60, len(futures_to_collection) * 2)
+        try:
+            for future in as_completed(futures_to_collection, timeout=timeout):
+                collection = futures_to_collection[future]
+                try:
+                    hits_count = future.result()
+                    collection.granule_count = hits_count
+
+                    # Cache the result
+                    cache_key = _build_cache_key(
+                        collection.concept_id,
+                        temporal_start,
+                        temporal_end,
+                        spatial_wkt,
+                    )
+                    ttl = _get_cache_ttl(collection.is_ongoing)
+                    cache.set(
+                        cache_key,
+                        json.dumps({"count": hits_count, "timestamp": time.time()}),
+                        ttl=ttl,
+                    )
+
+                except Exception as e:
+                    logger.warning(
+                        "Granule validation failed for %s: %s (type: %s)",
+                        collection.concept_id,
+                        e,
+                        type(e).__name__,
+                        exc_info=True,
+                    )
+                    failures += 1
+                    # Keep collection with None granule_count
+                    collection.granule_count = None
+
+        except TimeoutError:
+            logger.warning("Granule availability check timed out for some collections")
+            failures += len(futures_to_collection)
+
+    # Filter out collections with zero granules
+    validated = []
+    for collection in collections:
+        if collection.granule_count is not None and collection.granule_count > 0:
+            validated.append(collection)
+        elif collection.granule_count == 0:
+            zero_granule_count += 1
+
+    if zero_granule_count > 0 or failures > 0:
+        logger.info(
+            "Granule availability: %d/%d collections validated (filtered %d with no granules, %d failures)",
+            len(validated),
+            len(collections),
+            zero_granule_count,
+            failures,
+        )
+
+    return validated

--- a/tools/discover_data/utils/granule_availability.py
+++ b/tools/discover_data/utils/granule_availability.py
@@ -55,7 +55,11 @@ def _count_granules(
 
     # Add temporal constraint if provided
     if temporal_start is not None and temporal_end is not None:
-        params["temporal"] = f"{temporal_start.isoformat()}Z,{temporal_end.isoformat()}Z"
+        # Format as ISO 8601 with Z suffix (CMR requires this format)
+        # Replace timezone offset with Z to avoid "+00:00Z" which CMR rejects
+        start_str = temporal_start.isoformat().replace("+00:00", "Z")
+        end_str = temporal_end.isoformat().replace("+00:00", "Z")
+        params["temporal"] = f"{start_str},{end_str}"
 
     # Prepare shapefile if spatial constraint provided
     files = None
@@ -85,11 +89,7 @@ def _count_granules(
         return 0, 0
 
     except CMRError as e:
-        logger.error(
-            "CMR granule count failed for %s: %s",
-            collection_concept_id,
-            e,
-        )
+        logger.error("CMR granule count failed for %s: %s", collection_concept_id, e)
         raise
 
 
@@ -182,8 +182,7 @@ def validate_granule_availability(
     failures = 0
     zero_granule_count = 0
 
-    # Check cache first for all collections
-    futures_to_collection = {}
+    pending_validations = {}
     with ThreadPoolExecutor(max_workers=GRANULE_VALIDATION_MAX_WORKERS) as executor:
         for collection in collections:
             cache_key = _build_cache_key(
@@ -200,22 +199,22 @@ def validate_granule_availability(
                 collection.granule_count = cached_data["count"]
             else:
                 # Submit for parallel validation
-                future = executor.submit(
+                task = executor.submit(
                     _validate_single_collection,
                     collection,
                     temporal_start,
                     temporal_end,
                     spatial_wkt,
                 )
-                futures_to_collection[future] = collection
+                pending_validations[task] = collection
 
         # Process results as they complete (scale timeout with collection count)
-        timeout = max(60, len(futures_to_collection) * 2)
+        timeout = max(60, len(pending_validations) * 2)
         try:
-            for future in as_completed(futures_to_collection, timeout=timeout):
-                collection = futures_to_collection[future]
+            for task in as_completed(pending_validations, timeout=timeout):
+                collection = pending_validations[task]
                 try:
-                    hits_count = future.result()
+                    hits_count, took_ms = task.result()
                     collection.granule_count = hits_count
 
                     # Cache the result
@@ -246,7 +245,7 @@ def validate_granule_availability(
 
         except TimeoutError:
             logger.warning("Granule availability check timed out for some collections")
-            failures += len(futures_to_collection)
+            failures += len(pending_validations)
 
     # Filter out collections with zero granules
     validated = []

--- a/tools/discover_data/utils/granule_availability.py
+++ b/tools/discover_data/utils/granule_availability.py
@@ -20,7 +20,7 @@ from shapely.geometry import mapping
 
 from tools.models.output_model import CollectionMatch
 from util.cache import get_cache_client
-from util.cmr.client import CMRError, search_cmr
+from util.cmr.client import search_cmr
 
 logger = logging.getLogger(__name__)
 
@@ -53,15 +53,17 @@ def _count_granules(
     """
     params = {"collection_concept_id": collection_concept_id, "page_size": 0}
 
-    # Add temporal constraint if provided
-    if temporal_start is not None and temporal_end is not None:
+    if temporal_start is not None or temporal_end is not None:
         # Format as ISO 8601 with Z suffix (CMR requires this format)
         # Replace timezone offset with Z to avoid "+00:00Z" which CMR rejects
-        start_str = temporal_start.isoformat().replace("+00:00", "Z")
-        end_str = temporal_end.isoformat().replace("+00:00", "Z")
+        start_str = (
+            temporal_start.isoformat().replace("+00:00", "Z") if temporal_start is not None else ""
+        )
+        end_str = (
+            temporal_end.isoformat().replace("+00:00", "Z") if temporal_end is not None else ""
+        )
         params["temporal"] = f"{start_str},{end_str}"
 
-    # Prepare shapefile if spatial constraint provided
     files = None
     if spatial_wkt:
         geom = shapely_wkt.loads(spatial_wkt)
@@ -72,25 +74,19 @@ def _count_granules(
         file_obj = BytesIO(json.dumps(geojson).encode("utf-8"))
         files = {"shapefile": ("shapefile", file_obj, "application/geo+json")}
 
-    # Use search_cmr to make the request
-    try:
-        # Get first (and only) page - we only need the count, not the items
-        for page in search_cmr(
-            concept_type="granule",
-            search_params=params,
-            page_size=0,
-            method="POST",
-            files=files,
-        ):
-            return page.total_hits, page.took_ms
+    # page_size=0: CMR only populates total_hits, not items — one response page is all we need
+    for page in search_cmr(
+        concept_type="granule",
+        search_params=params,
+        page_size=0,
+        method="POST",
+        files=files,
+    ):
+        return page.total_hits, page.took_ms
 
-        # If no pages returned (shouldn't happen), return 0
-        logger.warning("No response from CMR for %s", collection_concept_id)
-        return 0, 0
-
-    except CMRError as e:
-        logger.error("CMR granule count failed for %s: %s", collection_concept_id, e)
-        raise
+    # If no pages returned (shouldn't happen), return 0
+    logger.warning("No response from CMR for %s", collection_concept_id)
+    return 0, 0
 
 
 def _build_cache_key(
@@ -149,10 +145,10 @@ def validate_granule_availability(
         spatial_wkt: Optional WKT geometry string for spatial constraint
 
     Returns:
-        list[CollectionMatch] with granule_count > 0
+        list[CollectionMatch] where granule_count > 0 or granule_count is None (validation failed)
     """
     # Only validate if constraints exist - without them, assume exploratory search
-    if not temporal_start and not spatial_wkt:
+    if not (temporal_start or temporal_end) and not spatial_wkt:
         logger.info("Skipping granule validation - no spatial or temporal constraints")
         return collections
 
@@ -174,13 +170,11 @@ def validate_granule_availability(
                 spatial_wkt,
             )
 
-            # Try cache first
             cached_result = cache.get(cache_key)
             if cached_result:
                 cached_data = json.loads(cached_result)
                 collection.granule_count = cached_data["count"]
             else:
-                # Submit for parallel validation
                 task = executor.submit(
                     _count_granules,
                     collection.concept_id,
@@ -196,7 +190,6 @@ def validate_granule_availability(
                 hits_count, _ = task.result()
                 collection.granule_count = hits_count
 
-                # Cache the result
                 cache_key = _build_cache_key(
                     collection.concept_id,
                     temporal_start,
@@ -210,25 +203,23 @@ def validate_granule_availability(
                     ttl=ttl,
                 )
 
-            except Exception as e:
+            except Exception:
                 logger.warning(
-                    "Granule validation failed for %s: %s (type: %s)",
+                    "Granule validation failed for %s",
                     collection.concept_id,
-                    e,
-                    type(e).__name__,
                     exc_info=True,
                 )
                 failures += 1
-                # Keep collection with None granule_count
                 collection.granule_count = None
-            failures += len(pending_validations)
 
-    # Filter out collections with zero granules
     validated = []
     for collection in collections:
-        if collection.granule_count is not None and collection.granule_count > 0:
+        if collection.granule_count is None:
+            # CMR failure — keep rather than silently drop
             validated.append(collection)
-        elif not collection.granule_count:
+        elif collection.granule_count > 0:
+            validated.append(collection)
+        else:
             zero_granule_count += 1
 
     if zero_granule_count > 0 or failures > 0:

--- a/tools/models/output_model.py
+++ b/tools/models/output_model.py
@@ -21,6 +21,7 @@ class DiscoveryStatus(str, Enum):
     INDIRECT_MATCHES = "indirect_matches"
     REFINEMENT_SUGGESTED = "refinement_suggested"
     NO_RESULTS = "no_results"
+    NO_GRANULES_IN_CONSTRAINTS = "no_granules_in_constraints"
     ERROR = "error"
 
 
@@ -90,6 +91,14 @@ class CollectionMatch(BaseModel):
     )
     related_entity_text: str | None = Field(
         None, description="The text content of the related entity"
+    )
+    is_ongoing: bool = Field(
+        default=False,
+        description="Whether the collection is still actively collecting data",
+    )
+    granule_count: int | None = Field(
+        None,
+        description="Number of granules matching spatio-temporal constraints (None if not validated)",
     )
 
 

--- a/util/cache.py
+++ b/util/cache.py
@@ -161,7 +161,6 @@ class RedisCache(CacheClient):
                     socket_connect_timeout=2,
                     socket_timeout=2,
                 )
-                # Test connection
                 self.client.ping()
                 logger.info(
                     "Successfully connected to local Redis at %s:%s", redis_host, redis_port

--- a/util/cache.py
+++ b/util/cache.py
@@ -144,13 +144,43 @@ class RedisCache(CacheClient):
 
     def _connect(self):
         """Establish Redis connection with proper error handling."""
+        # Try local development configuration first
+        redis_host = os.environ.get("REDIS_HOST")
+        redis_password = os.environ.get("REDIS_PASSWORD")
+        redis_port = os.environ.get("REDIS_PORT", "6379")
+
+        if redis_host:
+            # Local development mode - use direct environment variables
+            try:
+                logger.info("Using local Redis configuration (REDIS_HOST)")
+                self.client = redis.Redis(
+                    host=redis_host,
+                    port=int(redis_port),
+                    password=redis_password if redis_password else None,
+                    ssl=False,  # Local development typically doesn't use SSL
+                    socket_connect_timeout=2,
+                    socket_timeout=2,
+                )
+                # Test connection
+                self.client.ping()
+                logger.info(
+                    "Successfully connected to local Redis at %s:%s", redis_host, redis_port
+                )
+                return
+            except Exception as e:
+                logger.warning("Failed to connect to local Redis: %s", e)
+                self.client = None
+                return
+
+        # Production mode - use AWS Secrets Manager
         if not REDIS_SECRET_ID:
-            logger.info("REDIS_SECRET_ID not set, caching disabled")
+            logger.info("REDIS_SECRET_ID not set and no local Redis config found, caching disabled")
             self.client = None
             return
 
         try:
             creds = get_redis_credentials()
+            logger.info("Using AWS Secrets Manager Redis configuration")
             self.client = redis.Redis(
                 host=creds["host"],
                 port=int(creds["port"]),
@@ -163,7 +193,7 @@ class RedisCache(CacheClient):
 
             # Test connection
             self.client.ping()
-            logger.info("Successfully connected to Redis")
+            logger.info("Successfully connected to Redis via Secrets Manager")
 
         except Exception as e:
             logger.warning("Failed to connect to Redis: %s. Caching will be disabled.", e)

--- a/util/cmr/client.py
+++ b/util/cmr/client.py
@@ -8,9 +8,14 @@ from typing import Any, Literal
 import requests
 from pydantic import BaseModel, Field
 
+from util.environment import get_client_id
+
 logger = logging.getLogger(__name__)
 
 CMR_URL = os.environ.get("CMR_URL", "https://cmr.earthdata.nasa.gov")
+
+
+CLIENT_ID = get_client_id()
 
 CONCEPT_ENDPOINTS = {
     "collection": "/search/collections.umm_json",
@@ -57,7 +62,7 @@ def fetch_concept(concept_id: str, revision_id: str) -> dict[str, Any]:
     url = f"{CMR_URL}/search/concepts/{concept_id}/{revision_id}.umm_json"
 
     try:
-        response = requests.get(url, timeout=30)
+        response = requests.get(url, headers={"Client-Id": CLIENT_ID}, timeout=30)
         response.raise_for_status()
         return response.json()
     except requests.RequestException as e:
@@ -79,7 +84,7 @@ def fetch_associations(concept_id: str) -> dict[str, Any]:
     params = {"concept_id": concept_id, "include_has_granules": "false"}
 
     try:
-        response = requests.get(url, params=params, timeout=30)
+        response = requests.get(url, params=params, headers={"Client-Id": CLIENT_ID}, timeout=30)
         response.raise_for_status()
         data = response.json()
         items = data.get("items", [])
@@ -121,7 +126,7 @@ def search_cmr(
 
     endpoint = f"{CMR_URL}{CONCEPT_ENDPOINTS[concept_type]}"
     params = {**search_params, "page_size": page_size}
-    headers = {}
+    headers = {"Client-Id": CLIENT_ID}
     total_fetched = 0
 
     while True:

--- a/util/cmr/client.py
+++ b/util/cmr/client.py
@@ -3,9 +3,10 @@
 import logging
 import os
 from collections.abc import Generator
-from typing import Any
+from typing import Any, Literal
 
 import requests
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +16,24 @@ CONCEPT_ENDPOINTS = {
     "collection": "/search/collections.umm_json",
     "variable": "/search/variables.umm_json",
     "citation": "/search/citations.umm_json",
+    "granule": "/search/granules.umm_json",
 }
+
+
+class CMRSearchResponse(BaseModel):
+    """Single page of CMR search results with metadata."""
+
+    items: list[dict[str, Any]] = Field(description="List of concept metadata dictionaries")
+    total_hits: int = Field(
+        description="Total number of results matching the query (from CMR-Hits header)"
+    )
+    took_ms: int = Field(
+        description="Time CMR spent processing the request in milliseconds (from CMR-Took header)"
+    )
+    search_after: str | None = Field(
+        default=None, description="Token for fetching the next page (from CMR-Search-After header)"
+    )
+    page_size: int = Field(description="Number of items in this page")
 
 
 class CMRError(Exception):
@@ -77,17 +95,21 @@ def search_cmr(
     concept_type: str,
     search_params: dict[str, Any],
     page_size: int = 500,
-) -> Generator[list[dict[str, Any]]]:
+    method: Literal["GET", "POST"] = "GET",
+    files: dict[str, Any] | None = None,
+) -> Generator[CMRSearchResponse]:
     """
     Search CMR and yield pages of results using search-after pagination.
 
     Args:
-        concept_type: Type of concept (collection, variable, citation)
+        concept_type: Type of concept (collection, variable, citation, granule)
         search_params: Dictionary of CMR search parameters
         page_size: Number of results per page
+        method: HTTP method to use ("GET" or "POST")
+        files: Optional files dict for multipart/form-data (e.g., shapefile)
 
     Yields:
-        Lists of concept metadata dictionaries
+        CMRSearchResponse objects containing items and metadata
 
     Raises:
         CMRError: If the concept_type is unsupported or the request fails.
@@ -108,27 +130,61 @@ def search_cmr(
         )
 
         try:
-            response = requests.get(endpoint, params=params, headers=headers, timeout=60)
+            if method.upper() == "POST":
+                # POST request with optional files for spatial queries
+                response = requests.post(
+                    endpoint, data=params, files=files, headers=headers, timeout=60
+                )
+            else:
+                # GET request with params in URL
+                response = requests.get(endpoint, params=params, headers=headers, timeout=60)
+
             response.raise_for_status()
             data = response.json()
         except requests.RequestException as e:
             raise CMRError(f"CMR request failed: {e}") from e
 
         items = data.get("items", [])
+        total_hits = int(response.headers.get("CMR-Hits", 0))
+        took_ms = int(response.headers.get("CMR-Took", 0))
+        search_after_token = response.headers.get("CMR-Search-After")
+
+        # For count-only queries (page_size=0), return one page with empty items
+        if page_size == 0:
+            logger.info("Count-only query: %d total hits", total_hits)
+            yield CMRSearchResponse(
+                items=[],
+                total_hits=total_hits,
+                took_ms=took_ms,
+                search_after=None,
+                page_size=0,
+            )
+            break
+
         if not items:
             logger.info("No more results")
             break
 
         total_fetched += len(items)
-        hits = response.headers.get("CMR-Hits", "unknown")
-        logger.info("Fetched %d items (total: %d, hits: %s)", len(items), total_fetched, hits)
+        logger.info(
+            "Fetched %d items (total: %d, hits: %d, took: %dms)",
+            len(items),
+            total_fetched,
+            total_hits,
+            took_ms,
+        )
 
-        yield items
+        yield CMRSearchResponse(
+            items=items,
+            total_hits=total_hits,
+            took_ms=took_ms,
+            search_after=search_after_token,
+            page_size=len(items),
+        )
 
         # Get search-after token for next page
-        search_after = response.headers.get("CMR-Search-After")
-        if not search_after or len(items) < page_size:
+        if not search_after_token or len(items) < page_size:
             logger.info("Fetched all %d items", total_fetched)
             break
 
-        headers["CMR-Search-After"] = search_after
+        headers["CMR-Search-After"] = search_after_token

--- a/util/cmr/client.py
+++ b/util/cmr/client.py
@@ -136,7 +136,6 @@ def search_cmr(
                     endpoint, data=params, files=files, headers=headers, timeout=60
                 )
             else:
-                # GET request with params in URL
                 response = requests.get(endpoint, params=params, headers=headers, timeout=60)
 
             response.raise_for_status()

--- a/util/environment.py
+++ b/util/environment.py
@@ -8,11 +8,11 @@ def get_environment() -> str:
     Return the current deployment environment name.
 
     Reads ``ENVIRONMENT_NAME``, which is injected by Terraform at deploy time.
-    Use ``test`` in CI/CD pipelines. Defaults to ``local`` when the variable
+    Use ``test`` in CI/CD pipelines. Defaults to ``development`` when the variable
     is not set (e.g. local development without a configured ``.env`` file).
 
     Returns:
-        Environment name string (e.g. ``uat``, ``prod``, ``test``, ``local``)
+        Environment name string (e.g. ``uat``, ``prod``, ``test``, ``development``)
     """
     return os.environ.get("ENVIRONMENT_NAME", "development")
 

--- a/util/environment.py
+++ b/util/environment.py
@@ -14,19 +14,16 @@ def get_environment() -> str:
     Returns:
         Environment name string (e.g. ``uat``, ``prod``, ``test``, ``local``)
     """
-    return os.environ.get("ENVIRONMENT_NAME", "local")
+    return os.environ.get("ENVIRONMENT_NAME", "development")
 
 
-def get_client_id(app: str = "mcp") -> str:
+def get_client_id() -> str:
     """
-    Build an EED client identifier for the given application.
+    Build an client identifier for the given application.
 
-    Format: ``eed-{environment}-{app}``
-
-    Args:
-        app: Application name suffix (default: ``mcp``)
+    Format: ``eed-{environment}-mcp``
 
     Returns:
         Client ID string (e.g. ``eed-uat-mcp``)
     """
-    return f"eed-{get_environment()}-{app}"
+    return f"eed-{get_environment()}-mcp"

--- a/util/environment.py
+++ b/util/environment.py
@@ -1,0 +1,32 @@
+"""Environment utility for resolving the current deployment environment."""
+
+import os
+
+
+def get_environment() -> str:
+    """
+    Return the current deployment environment name.
+
+    Reads ``ENVIRONMENT_NAME``, which is injected by Terraform at deploy time.
+    Use ``test`` in CI/CD pipelines. Defaults to ``local`` when the variable
+    is not set (e.g. local development without a configured ``.env`` file).
+
+    Returns:
+        Environment name string (e.g. ``uat``, ``prod``, ``test``, ``local``)
+    """
+    return os.environ.get("ENVIRONMENT_NAME", "local")
+
+
+def get_client_id(app: str = "mcp") -> str:
+    """
+    Build an EED client identifier for the given application.
+
+    Format: ``eed-{environment}-{app}``
+
+    Args:
+        app: Application name suffix (default: ``mcp``)
+
+    Returns:
+        Client ID string (e.g. ``eed-uat-mcp``)
+    """
+    return f"eed-{get_environment()}-{app}"

--- a/util/natural_language_geocoder.py
+++ b/util/natural_language_geocoder.py
@@ -15,7 +15,7 @@ from natural_language_geocoding import extract_geometry_from_text
 from natural_language_geocoding.geocode_index.geocode_index_place_lookup import (
     GeocodeIndexPlaceLookup,
 )
-from shapely.ops import orient
+from shapely import orient_polygons
 
 logger = logging.getLogger(__name__)
 
@@ -123,8 +123,8 @@ def _normalize_geometry_to_wkt(geometry) -> str | None:
             raise ValueError("Geometry is invalid and could not be repaired")
 
     if geometry.geom_type in ("Polygon", "MultiPolygon"):
-        # Orient with sign=1.0 ensures counter-clockwise exterior rings (CMR requirement)
-        geometry = orient(geometry, sign=1.0)
+        # Forces CCW exterior rings and CW interior rings for CMR
+        geometry = orient_polygons(geometry)
 
     # Convert to WKT
     return geometry.wkt

--- a/util/natural_language_geocoder.py
+++ b/util/natural_language_geocoder.py
@@ -15,7 +15,7 @@ from natural_language_geocoding import extract_geometry_from_text
 from natural_language_geocoding.geocode_index.geocode_index_place_lookup import (
     GeocodeIndexPlaceLookup,
 )
-from shapely import orient_polygons
+from shapely import make_valid, orient_polygons
 
 logger = logging.getLogger(__name__)
 
@@ -108,17 +108,17 @@ def _normalize_geometry_to_wkt(geometry) -> str | None:
     if not hasattr(geometry, "geom_type"):
         raise ValueError("Expected Shapely geometry object")
 
-    # Repair invalid geometries using buffer(0)
+    # Repair invalid geometries using make_valid()
     # This fixes self-intersections, duplicate vertices, and topology issues
     if not geometry.is_valid:
-        logger.warning("Invalid geometry detected, attempting to fix with buffer(0)")
+        logger.warning("Invalid geometry detected, attempting to fix with make_valid()")
         try:
-            geometry = geometry.buffer(0)
+            geometry = make_valid(geometry)
         except Exception as e:
             raise ValueError(f"Invalid geometry: {e}") from e
 
         if geometry.is_empty:
-            raise ValueError("Geometry is empty after buffer(0) repair")
+            raise ValueError("Geometry is empty after make_valid() repair")
         if not geometry.is_valid:
             raise ValueError("Geometry is invalid and could not be repaired")
 

--- a/util/natural_language_geocoder.py
+++ b/util/natural_language_geocoder.py
@@ -15,6 +15,7 @@ from natural_language_geocoding import extract_geometry_from_text
 from natural_language_geocoding.geocode_index.geocode_index_place_lookup import (
     GeocodeIndexPlaceLookup,
 )
+from shapely.ops import orient
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +90,7 @@ def _normalize_geometry_to_wkt(geometry) -> str | None:
     Convert Shapely geometry to WKT format for spatial queries.
 
     The geocoder and simplify_geometry both return Shapely BaseGeometry objects.
-    This converts them to WKT strings with normalized formatting for database queries.
+    This converts them to WKT strings with normalized formatting for database and CMR queries.
 
     Args:
         geometry: Shapely geometry object (Point, Polygon, MultiPolygon, etc.)
@@ -120,6 +121,10 @@ def _normalize_geometry_to_wkt(geometry) -> str | None:
             raise ValueError("Geometry is empty after buffer(0) repair")
         if not geometry.is_valid:
             raise ValueError("Geometry is invalid and could not be repaired")
+
+    if geometry.geom_type in ("Polygon", "MultiPolygon"):
+        # Orient with sign=1.0 ensures counter-clockwise exterior rings (CMR requirement)
+        geometry = orient(geometry, sign=1.0)
 
     # Convert to WKT
     return geometry.wkt


### PR DESCRIPTION
Added granule availability validation and local dev infrastructure

Main feature: collections are now filtered by checking if they actually have granules matching the user's spatial/temporal constraints. This prevents returning collections that technically match the search but have no data for the requested time/location.

Enhanced CMR client to support granule searches and expose response metadata (total hits, timing, pagination tokens) from headers. Updated existing code to use the new response structure.

Added local development support for database and Redis - can now run against localhost instead of AWS services during development. Updated README with setup instructions.

Added new granule validation tests, local dev tests for cache/database, and natural language geocoding tests. Database module is now at 100% coverage. Standardized test files to use monkeypatch instead of @patch decorators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Granule-availability validation in discovery (filters collections; new NO_GRANULES_IN_CONSTRAINTS status). Collection metadata now tracks ongoing state and granule counts.
  * Search API now returns paginated response objects, supports granule queries and POST/multipart requests.
  * Redis connection supports local env-based and Secrets Manager paths; DB host override honored.
  * Geocoding normalizes polygon orientation for compatibility.

* **Documentation**
  * README expanded with local PostgreSQL/Redis setup, server start details, inspector notes, and compatibility list.

* **Tests**
  * Extensive new and updated tests covering discovery, granule validation, database, cache, pagination, and geocoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->