### PR TITLE
CMRNLP-50: Validate all requests to get granule count

### DIFF
--- a/tests/tools/discover_data/utils/test_granule_availability.py
+++ b/tests/tools/discover_data/utils/test_granule_availability.py
@@ -223,28 +223,8 @@ class TestGetCacheTTL:
 class TestValidateGranuleAvailability:
     """Tests for validate_granule_availability function."""
 
-    def test_skips_validation_without_constraints(self, monkeypatch):
-        """Test that validation is skipped when no spatial or temporal constraints exist."""
-        collections = [
-            CollectionMatch(
-                concept_id="C1234-PROVIDER",
-                title="Test collection",
-                similarity_score=0.9,
-                match_type="direct",
-            )
-        ]
-
-        mock_count = Mock()
-        monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
-
-        result = granule_availability.validate_granule_availability(collections, None, None, None)
-
-        assert len(result) == 1
-        assert result[0].concept_id == "C1234-PROVIDER"
-        mock_count.assert_not_called()
-
-    def test_skips_validation_only_when_no_temporal_and_no_spatial(self, monkeypatch):
-        """Test that validation is only skipped when BOTH temporal bounds AND spatial are absent."""
+    def test_validates_without_constraints(self, monkeypatch):
+        """Test that validation runs even when no spatial or temporal constraints exist."""
         collections = [
             CollectionMatch(
                 concept_id="C1234-PROVIDER",
@@ -258,16 +238,14 @@ class TestValidateGranuleAvailability:
         mock_cache.get.return_value = None
         monkeypatch.setattr(granule_availability, "get_cache_client", lambda: mock_cache)
 
-        mock_count = Mock(return_value=(10, 5))
+        mock_count = Mock(return_value=(42, 5))
         monkeypatch.setattr(granule_availability, "_count_granules", mock_count)
 
-        # Only temporal_end provided (no temporal_start, no spatial)
-        result = granule_availability.validate_granule_availability(
-            collections, None, datetime(2023, 12, 31, tzinfo=UTC), None
-        )
+        result = granule_availability.validate_granule_availability(collections, None, None, None)
 
         mock_count.assert_called_once()
-        assert result[0].granule_count == 10
+        assert len(result) == 1
+        assert result[0].granule_count == 42
 
     def test_filters_collections_with_zero_granules(self, monkeypatch):
         """Test that collections with zero granules are filtered out."""

--- a/tools/discover_data/utils/granule_availability.py
+++ b/tools/discover_data/utils/granule_availability.py
@@ -142,10 +142,11 @@ def validate_granule_availability(
     spatial_wkt: str | None,
 ) -> list[CollectionMatch]:
     """
-    Validate granule availability for collections with spatio-temporal constraints.
+    Validate granule availability for all collections.
 
-    Checks each collection for granules within the constraints. Collections with zero granules
-    are filtered out. Results are cached with TTL based on whether collections are ongoing.
+    Checks each collection for granules, optionally filtered by spatio-temporal constraints.
+    Collections with zero granules are filtered out. Results are cached with TTL based on
+    whether collections are ongoing.
 
     Args:
         collections: List of collections to validate
@@ -154,13 +155,8 @@ def validate_granule_availability(
         spatial_wkt: Optional WKT geometry string for spatial constraint
 
     Returns:
-        list[CollectionMatch] where granule_count > 0 or granule_count is None (validation failed)
+        list[CollectionMatch] where granule_count > 0
     """
-    # Only validate if constraints exist - without them, assume exploratory search
-    if not (temporal_start or temporal_end) and not spatial_wkt:
-        logger.info("Skipping granule validation - no spatial or temporal constraints")
-        return collections
-
     if not collections:
         return collections
 


### PR DESCRIPTION
Remove the guard preventing check on collections without temporal or spatial filtering so that accurate granule counts are returned for all requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Granule availability is now validated for all collections consistently, regardless of whether spatial or temporal constraints are provided. This ensures more complete and accurate results in all query scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->