### PR TITLE
CMRNLP-91: Adds fallback for start and end time for UMM-T definitions

### DIFF
--- a/tests/tools/discover_data/utils/test_tool_associations.py
+++ b/tests/tools/discover_data/utils/test_tool_associations.py
@@ -163,8 +163,8 @@ class TestFetchToolAssociations:
 
         assert result["tools"] == tools
 
-    def test_raises_when_tool_ids_exist_but_tool_metadata_is_empty(self, monkeypatch):
-        """Empty metadata for reported tool IDs should be treated as a fetch failure."""
+    def test_returns_empty_tools_when_tool_ids_exist_but_tool_metadata_is_empty(self, monkeypatch):
+        """Empty actionable metadata for reported tool IDs should be non-fatal."""
         monkeypatch.setattr(
             "tools.discover_data.utils.tool_associations.fetch_associations",
             lambda concept_id: {"tools": ["TL1-PROV"]},
@@ -178,8 +178,10 @@ class TestFetchToolAssociations:
             lambda ids: [],
         )
 
-        with pytest.raises(ToolAssociationError, match="C1234-PROVIDER"):
-            _fetch_tool_associations("C1234-PROVIDER")
+        result = _fetch_tool_associations("C1234-PROVIDER")
+
+        assert result["tools"] == []
+        assert result["tags"] == {}
 
     def test_returns_tags_from_fetch_collection_tags(self, monkeypatch):
         """Should include tags returned by fetch_collection_tags in result."""
@@ -608,3 +610,100 @@ class TestBuildExplorationLinks:
         wv = next(link for link in links if link["name"] == "NASA Worldview")
         assert "LayerA" in wv["url"]
         assert "LayerB" in wv["url"]
+
+    def test_uses_collection_temporal_as_fallback_for_required_inputs(self):
+        """Collection start/end should satisfy required temporal inputs when user provides none."""
+        giovanni_tool = {
+            "name": "Giovanni",
+            "base_url": "https://giovanni.gsfc.nasa.gov/giovanni",
+            "url_template": "https://giovanni.gsfc.nasa.gov/giovanni/#service=TmAvMp{?starttime,endtime}",
+            "query_inputs": [
+                {
+                    "value_name": "starttime",
+                    "value_type": "https://schema.org/startDate",
+                    "required": True,
+                },
+                {
+                    "value_name": "endtime",
+                    "value_type": "https://schema.org/endDate",
+                    "required": False,
+                },
+            ],
+        }
+        collection_start = datetime(2000, 1, 1, tzinfo=UTC)
+        collection_end = datetime(2024, 12, 31, tzinfo=UTC)
+
+        links = _build_exploration_links(
+            [giovanni_tool],
+            "C1-P",
+            temporal=None,
+            spatial=None,
+            short_name=None,
+            gibs_layers=[],
+            collection_start_date=collection_start,
+            collection_end_date=collection_end,
+        )
+        names = [link["name"] for link in links]
+        assert "Giovanni" in names
+        giovanni_link = next(link for link in links if link["name"] == "Giovanni")
+        assert "starttime=2000-01-01" in giovanni_link["url"]
+        assert "endtime=2024-12-31" in giovanni_link["url"]
+
+    def test_user_temporal_takes_precedence_over_collection_fallback(self):
+        """Explicit user temporal should override collection start/end in tool URL resolution."""
+        tool = {
+            "name": "Giovanni",
+            "base_url": "https://giovanni.gsfc.nasa.gov/giovanni",
+            "url_template": "https://giovanni.gsfc.nasa.gov/giovanni/#service=TmAvMp{?starttime}",
+            "query_inputs": [
+                {
+                    "value_name": "starttime",
+                    "value_type": "https://schema.org/startDate",
+                    "required": True,
+                },
+            ],
+        }
+        user_temporal = TemporalConstraint(start_date=datetime(2020, 6, 1, tzinfo=UTC))
+
+        links = _build_exploration_links(
+            [tool],
+            "C1-P",
+            temporal=user_temporal,
+            spatial=None,
+            short_name=None,
+            gibs_layers=[],
+            collection_start_date=datetime(2000, 1, 1, tzinfo=UTC),
+            collection_end_date=datetime(2024, 12, 31, tzinfo=UTC),
+        )
+        giovanni_link = next(link for link in links if link["name"] == "Giovanni")
+        assert "starttime=2020-06-01" in giovanni_link["url"]
+        assert "2000-01-01" not in giovanni_link["url"]
+
+    def test_empty_user_temporal_still_uses_collection_fallback(self):
+        """TemporalConstraint with no bounds should be treated as absent for fallback behavior."""
+        tool = {
+            "name": "Giovanni",
+            "base_url": "https://giovanni.gsfc.nasa.gov/giovanni",
+            "url_template": "https://giovanni.gsfc.nasa.gov/giovanni/#service=TmAvMp{?starttime}",
+            "query_inputs": [
+                {
+                    "value_name": "starttime",
+                    "value_type": "https://schema.org/startDate",
+                    "required": True,
+                },
+            ],
+        }
+
+        links = _build_exploration_links(
+            [tool],
+            "C1-P",
+            temporal=TemporalConstraint(),
+            spatial=None,
+            short_name=None,
+            gibs_layers=[],
+            collection_start_date=datetime(2000, 1, 1, tzinfo=UTC),
+            collection_end_date=datetime(2024, 12, 31, tzinfo=UTC),
+        )
+
+        giovanni_link = next(link for link in links if link["name"] == "Giovanni")
+        assert "starttime=2000-01-01" in giovanni_link["url"]

--- a/tools/discover_data/utils/tool_associations.py
+++ b/tools/discover_data/utils/tool_associations.py
@@ -10,7 +10,10 @@ Temporal behavior by link type is intentionally not uniform:
     temporal constraints are present.
 - Worldview/GIBS: may fall back to collection end date for initial time/layer
     usability when user temporal constraints are absent.
-- UMM-T templates: resolve temporal values from user constraints only.
+- UMM-T templates: prefer user-extracted temporal constraints; fall back to
+    collection temporal coverage when user constraints are absent, so that
+    tools with required temporal inputs (e.g. Giovanni starttime) can still
+    produce a valid link representing the full span of the dataset.
 
 These decisions are documented in each link-generation helper module so policy
 and implementation remain colocated.
@@ -71,6 +74,7 @@ def _build_exploration_links(  # pylint: disable=too-many-arguments
     short_name: str | None,
     gibs_layers: list[str],
     collection_end_date: datetime | None = None,
+    collection_start_date: datetime | None = None,
 ) -> list[dict]:
     """
     Build the full ordered exploration links list for a collection.
@@ -82,6 +86,29 @@ def _build_exploration_links(  # pylint: disable=too-many-arguments
     """
     links: list[dict] = [_earthdata_search_link(concept_id, temporal, spatial, collection_end_date)]
     guaranteed_worldview_link_added = False
+
+    # When the user provided no temporal bounds, fall back to the full
+    # collection coverage span so tools with required temporal inputs (e.g.
+    # Giovanni starttime) can still produce a valid link.
+    user_has_temporal_bounds = temporal is not None and (
+        temporal.start_date is not None or temporal.end_date is not None
+    )
+    effective_temporal = temporal if user_has_temporal_bounds else None
+    if effective_temporal is None and (
+        collection_start_date is not None or collection_end_date is not None
+    ):
+        effective_temporal = TemporalConstraint(
+            start_date=collection_start_date, end_date=collection_end_date
+        )
+
+    logger.debug(
+        "Tool link temporal context for %s: user_temporal=(%s,%s) fallback_temporal=(%s,%s)",
+        concept_id,
+        temporal.start_date if temporal is not None else None,
+        temporal.end_date if temporal is not None else None,
+        effective_temporal.start_date if effective_temporal is not None else None,
+        effective_temporal.end_date if effective_temporal is not None else None,
+    )
 
     if gibs_layers:
         links.append(_worldview_link(gibs_layers, temporal, spatial, collection_end_date))
@@ -101,7 +128,7 @@ def _build_exploration_links(  # pylint: disable=too-many-arguments
             continue
 
         resolved_tool = _resolve_tool_url(
-            tool, concept_id, temporal, spatial, short_name, gibs_layers=gibs_layers
+            tool, concept_id, effective_temporal, spatial, short_name, gibs_layers=gibs_layers
         )
         if resolved_tool is not None:
             links.append(resolved_tool)
@@ -151,7 +178,12 @@ def _fetch_tool_associations(concept_id: str) -> list[dict]:
 
     tools = fetch_tool_metadata(tool_ids)
     if not tools:
-        raise ToolAssociationError(f"Failed to fetch tool metadata for {concept_id}")
+        logger.info(
+            "No actionable tool metadata for %s (tool_ids=%s); continuing without tool links",
+            concept_id,
+            tool_ids,
+        )
+        return {"tools": [], "tags": tags}
 
     return {"tools": tools, "tags": tags}
 
@@ -212,6 +244,7 @@ def enrich_with_tool_associations(
                     collection.short_name,
                     gibs_layers,
                     collection_end_date=cov.end_date if cov else None,
+                    collection_start_date=cov.start_date if cov else None,
                 )
             else:
                 ctx = contextvars.copy_context()
@@ -243,6 +276,7 @@ def enrich_with_tool_associations(
                     collection.short_name,
                     gibs_layers,
                     collection_end_date=cov.end_date if cov else None,
+                    collection_start_date=cov.start_date if cov else None,
                 )
 
                 key = _cache_key(collection.concept_id)

--- a/tools/discover_data/utils/umm_tool_links.py
+++ b/tools/discover_data/utils/umm_tool_links.py
@@ -1,9 +1,10 @@
 """CMR UMM-derived tool-link helpers for discover_data.
 
 Temporal policy:
-- Temporal template values are resolved from user-extracted temporal
-    constraints only.
-- No temporal fallback is injected from collection metadata.
+- Temporal template values are resolved from whatever TemporalConstraint is
+    passed in.
+- Callers (tool_associations.py) are responsible for supplying a collection-
+    derived fallback constraint when no user temporal constraint is available.
 """
 
 import logging
@@ -122,6 +123,13 @@ def _resolve_tool_url(
             query_input.get("value_type"), concept_id, temporal, spatial, short_name
         )
         values[value_name] = resolved
+        logger.debug(
+            "Resolved tool input %s for %s: required=%s value=%s",
+            value_name,
+            tool.get("name"),
+            query_input.get("required"),
+            resolved,
+        )
         if query_input.get("required") and resolved is None:
             missing_required_names.append(value_name)
 


### PR DESCRIPTION
This PR fixes missing Giovanni exploration links when users do not provide temporal constraints.

## What changed
- Updated UMM-T link generation to treat missing user temporal bounds as a fallback case and use collection temporal coverage instead.
- Added/updated fallback behavior so required UMM-T inputs like starttime can be resolved from collection metadata when query-time temporal values are absent.
- Preserved precedence of user-provided temporal constraints when they are present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced temporal data fallback: Tool links now use collection start/end dates when user temporal constraints are unavailable
  * Improved error handling for missing tool metadata

* **Tests**
  * Added test coverage for collection temporal fallback behavior in tool URL generation

* **Chores**
  * Enhanced debug logging for temporal context resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->