### PR TITLE
CMRNLP-97: Improve error handling for CMR errors

### DIFF
--- a/tests/utils/cmr/test_client.py
+++ b/tests/utils/cmr/test_client.py
@@ -292,6 +292,17 @@ class TestSearchCmrGet:
         with pytest.raises(CMRError, match="CMR request failed"):
             list(search_cmr("collection", {}))
 
+    def test_includes_cmr_error_details_from_http_response(self, monkeypatch):
+        """Should surface CMR error payload details when a request returns HTTP 400."""
+        bad_response = _make_response(json_data={"errors": ["Invalid shapefile geometry"]})
+        bad_response.raise_for_status.side_effect = requests.HTTPError(
+            "400 Client Error", response=bad_response
+        )
+        monkeypatch.setattr("util.cmr.client.requests.get", Mock(return_value=bad_response))
+
+        with pytest.raises(CMRError, match="Invalid shapefile geometry"):
+            list(search_cmr("collection", {}))
+
     def test_count_only_query_returns_single_page(self, monkeypatch):
         """Should yield one page with empty items for page_size=0 count queries."""
         response = _make_response(

--- a/util/cmr/client.py
+++ b/util/cmr/client.py
@@ -50,6 +50,29 @@ class CMRError(Exception):
     """Raised when a CMR API request fails."""
 
 
+def _extract_cmr_error_detail(response: requests.Response | Any) -> str | None:
+    """Extract a concise error message from a failed CMR HTTP response."""
+    try:
+        payload = response.json()
+    except Exception:  # pylint: disable=broad-exception-caught
+        payload = None
+
+    if isinstance(payload, dict):
+        errors = payload.get("errors")
+        if isinstance(errors, list) and errors:
+            return "; ".join(str(err) for err in errors if err)
+
+        message = payload.get("message") or payload.get("error")
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+
+    text = getattr(response, "text", None)
+    if isinstance(text, str) and text.strip():
+        return text.strip()[:500]
+
+    return None
+
+
 def fetch_concept(concept_id: str, revision_id: str) -> dict[str, Any]:
     """
     Fetch concept metadata from CMR.
@@ -272,6 +295,11 @@ def search_cmr(
             response.raise_for_status()
             data = response.json()
         except requests.RequestException as e:
+            response = getattr(e, "response", None)
+            if response is not None:
+                detail = _extract_cmr_error_detail(response)
+                if detail:
+                    raise CMRError(f"CMR request failed: {detail}") from e
             raise CMRError(f"CMR request failed: {e}") from e
 
         items = data.get("items", [])


### PR DESCRIPTION
Previously, when CMR returned a 4xx/5xx response, `search_cmr` raised a generic `CMRError`
using only `str(e)` (the HTTP status line), discarding the response body. This made errors
like invalid shapefile uploads opaque.

### Changes

- Added `_extract_cmr_error_detail()` helper in `util/cmr/client.py` that extracts the error
  message from a failed CMR response, checking in order:
  1. `errors[]` array (CMR's standard error format)
  2. `message` or `error` dict keys
  3. Raw response text (capped at 500 chars)
- Updated the `search_cmr` exception handler to call this helper and include the detail in
  the raised `CMRError`

### Example

**Before:**
CMR request failed: 400 Client Error: Bad Request for url: .../collections.umm_json

**After:**
 CMR request failed: Failed to parse shapefile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for CMR API requests to display specific error details from API responses instead of generic failure messages.

* **Tests**
  * Added test coverage to verify proper extraction and display of error messages when CMR API returns error payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->