### PR TITLE
CMRNLP-97: Adds session tracing

### DIFF
--- a/tests/tools/get_collections/test_get_collections_tool.py
+++ b/tests/tools/get_collections/test_get_collections_tool.py
@@ -1,6 +1,7 @@
 """Tests for the get_collections MCP tool."""
 
 import importlib
+from unittest.mock import patch
 
 from util.cmr.client import CMRError, CMRSearchResponse
 
@@ -263,3 +264,20 @@ def test_get_collections_returns_error_on_invalid_spatial_wkt():
 
     assert output["status"] == "error"
     assert "Invalid WKT geometry" in output["error_message"]
+
+
+def test_get_collections_calls_trace_update(monkeypatch):
+    """Tool should emit Langfuse trace updates using the shared helper."""
+    tool = _load_tool()
+    page = CMRSearchResponse(items=[], total_hits=0, took_ms=5, search_after=None, page_size=0)
+
+    def fake_search_cmr(**_kwargs):
+        yield page
+
+    monkeypatch.setattr(tool, "search_cmr", fake_search_cmr)
+
+    with patch.object(tool, "trace_update") as mock_trace_update:
+        output = tool.get_collections(query="modis")
+
+    assert output["status"] == "no_results"
+    assert mock_trace_update.called

--- a/tests/tools/get_granules/test_get_granules_tool.py
+++ b/tests/tools/get_granules/test_get_granules_tool.py
@@ -1,6 +1,7 @@
 """Tests for the get_granules MCP tool."""
 
 import importlib
+from unittest.mock import patch
 
 from util.cmr.client import CMRError, CMRSearchResponse
 
@@ -208,3 +209,20 @@ def test_get_granules_returns_error_on_invalid_spatial_wkt():
 
     assert output["status"] == "error"
     assert "Invalid WKT geometry" in output["error_message"]
+
+
+def test_get_granules_calls_trace_update(monkeypatch):
+    """Tool should emit Langfuse trace updates using the shared helper."""
+    tool = _load_tool()
+    page = CMRSearchResponse(items=[], total_hits=0, took_ms=5, search_after=None, page_size=0)
+
+    def fake_search_cmr(**_kwargs):
+        yield page
+
+    monkeypatch.setattr(tool, "search_cmr", fake_search_cmr)
+
+    with patch.object(tool, "trace_update") as mock_trace_update:
+        output = tool.get_granules(collection_concept_id="C123-PROV")
+
+    assert output["status"] == "no_results"
+    assert mock_trace_update.called

--- a/tests/utils/test_langfuse.py
+++ b/tests/utils/test_langfuse.py
@@ -1,0 +1,55 @@
+"""Tests for util.langfuse helpers."""
+
+from unittest.mock import MagicMock
+
+import util.langfuse as langfuse_utils
+
+
+def test_trace_update_uses_mcp_session_id_when_not_provided(monkeypatch):
+    """trace_update should infer session_id from FastMCP context when available."""
+    mock_client = MagicMock()
+    monkeypatch.setattr(langfuse_utils, "get_langfuse", lambda: mock_client)
+    monkeypatch.setattr(
+        langfuse_utils,
+        "_resolve_session_id_from_mcp_context",
+        lambda: "mcp-session-123",
+    )
+
+    langfuse_utils.trace_update(metadata={"key": "value"})
+
+    mock_client.update_current_trace.assert_called_once_with(
+        metadata={"key": "value"},
+        session_id="mcp-session-123",
+    )
+
+
+def test_trace_update_prefers_explicit_session_id(monkeypatch):
+    """Explicit session_id should override inferred MCP session context."""
+    mock_client = MagicMock()
+    monkeypatch.setattr(langfuse_utils, "get_langfuse", lambda: mock_client)
+    monkeypatch.setattr(
+        langfuse_utils,
+        "_resolve_session_id_from_mcp_context",
+        lambda: "mcp-session-123",
+    )
+
+    langfuse_utils.trace_update(
+        tags=["collections"],
+        session_id="explicit-session-456",
+    )
+
+    mock_client.update_current_trace.assert_called_once_with(
+        tags=["collections"],
+        session_id="explicit-session-456",
+    )
+
+
+def test_trace_update_noop_without_data_or_session(monkeypatch):
+    """trace_update should avoid client updates when nothing can be attached."""
+    mock_client = MagicMock()
+    monkeypatch.setattr(langfuse_utils, "get_langfuse", lambda: mock_client)
+    monkeypatch.setattr(langfuse_utils, "_resolve_session_id_from_mcp_context", lambda: None)
+
+    langfuse_utils.trace_update()
+
+    mock_client.update_current_trace.assert_not_called()

--- a/tools/get_collections/tool.py
+++ b/tools/get_collections/tool.py
@@ -24,6 +24,7 @@ from util.cmr.search_tools import (
     format_temporal_range,
     normalize_collection_item,
 )
+from util.langfuse import trace_update
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,16 @@ def get_collections(  # pylint: disable=too-many-arguments,unused-argument
     or multi-decadal — presence in results does not confirm data exists for a specific region or
     period. Use filters here, then confirm actual granule availability with get_granules.
     """
+    trace_update(
+        tags=["cmr", "collections"],
+        metadata={
+            "has_query": bool(query),
+            "has_temporal": temporal_start_date is not None or temporal_end_date is not None,
+            "has_spatial": spatial_wkt_geometry is not None,
+            "page_size": page_size,
+        },
+    )
+
     try:
         params = GetCollectionsInput(**locals())
 

--- a/tools/get_granules/tool.py
+++ b/tools/get_granules/tool.py
@@ -17,6 +17,7 @@ from models.tools.get_granules import (
 )
 from util.cmr.client import CMRError, search_cmr
 from util.cmr.search_tools import build_spatial_files, format_temporal_range, normalize_granule_item
+from util.langfuse import trace_update
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,16 @@ def get_granules(  # pylint: disable=too-many-arguments,unused-argument
     filters the results reflect the entire collection archive and total_hits will be non-zero
     even when no granules exist for the area or period the user cares about.
     """
+    trace_update(
+        tags=["cmr", "granules"],
+        metadata={
+            "collection_concept_id": collection_concept_id,
+            "has_temporal": temporal_start_date is not None or temporal_end_date is not None,
+            "has_spatial": spatial_wkt_geometry is not None,
+            "page_size": page_size,
+        },
+    )
+
     try:
         params = GetGranulesInput(**locals())
 

--- a/util/langfuse.py
+++ b/util/langfuse.py
@@ -69,6 +69,23 @@ def initialize_langfuse_client() -> Langfuse | None:
     return get_langfuse()
 
 
+def _resolve_session_id_from_mcp_context() -> str | None:
+    """Resolve session id from FastMCP request context when available."""
+    try:
+        # Import lazily so this utility also works in non-FastMCP runtimes.
+        from fastmcp.server.dependencies import get_context  # type: ignore
+
+        ctx = get_context()
+        if ctx is None:
+            return None
+
+        session_id = getattr(ctx, "session_id", None)
+        return session_id if isinstance(session_id, str) and session_id else None
+    except Exception:
+        # Outside request context (or FastMCP not available), no session can be inferred.
+        return None
+
+
 def trace_update(
     metadata: dict | None = None,
     tags: list[str] | None = None,
@@ -93,8 +110,9 @@ def trace_update(
         kwargs["metadata"] = metadata
     if tags is not None:
         kwargs["tags"] = tags
-    if session_id is not None:
-        kwargs["session_id"] = session_id
+    resolved_session_id = session_id or _resolve_session_id_from_mcp_context()
+    if resolved_session_id is not None:
+        kwargs["session_id"] = resolved_session_id
 
     if kwargs:
         client.update_current_trace(**kwargs)


### PR DESCRIPTION
This PR adds session-aware tracing to Langfuse so MCP requests can be correlated end-to-end without requiring every tool call to manually pass a session id.

### What changed

1. Added automatic session id resolution from FastMCP request context in the shared Langfuse helper.
2. Updated trace updates to prefer an explicitly provided session id, but fall back to inferred MCP session id when available.
3. Added trace metadata emission in get_collections and get_granules so requests capture useful query context (filters/paging/collection id).
4. Added tests for:
5. Session id inference behavior.
6. Explicit session id precedence.
7. Tool-level trace_update invocation for collections and granules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for trace updates in collection and granule retrieval operations.
  * Added unit tests for session ID resolution and trace update functionality.

* **Improvements**
  * Enhanced tracing to capture query parameters and filter details for improved observability.
  * Improved session ID tracking for more accurate trace identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->