### PR TITLE
CMRNLP-103: Remove empty resource statement

### DIFF
--- a/terraform/modules/application/mcp-server.tf
+++ b/terraform/modules/application/mcp-server.tf
@@ -83,15 +83,6 @@ resource "aws_iam_role_policy" "mcp_task" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "SecretsManager"
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:GetSecretValue"
-        ]
-        Resource = [
-        ]
-      },
-      {
         Sid    = "Bedrock"
         Effect = "Allow"
         Action = [


### PR DESCRIPTION
# Overview

## What is the feature?

This just fixes the terraform deployment by removing this empty resource statement. Empty resources are no-ops and just cause deployment failures. We also needed to remove some ECR containers manually and redeploy to fix the remaining issues

## What is the Solution?

Just removed the empty statement

## What areas of the application does this impact?

Terraform infrastructure resources

## Testing

### Reproduction steps

- **Tool tested:*NA* (e.g., `get_collections`, `get_granules`)
- **Input payload or query used:*NA*

1. Ensure the terraform deployment is working on bamboo

### Attachments

<img width="1641" height="81" alt="image" src="https://github.com/user-attachments/assets/d7c86829-e159-4b39-83e5-d2065d4887c4" />

## Pre-Review Checklist

- [NA] Added automated tests that prove the fix is effective or feature works
- [NA] Verified new and existing unit tests pass locally
- [x] Performed a self-review of the code
- [NA] Commented code, particularly in hard-to-understand areas
- [NA] Updated corresponding documentation
- [x] Verified changes generate no new warnings
- [NA] Bumped `pyproject.toml` and `manifest.json` versions according to the [Versioning Methodology](docs/developers/versioning.md) if inputs, outputs, or logic changed
- [NA] Added any new root-level Python directories to `McpServerDockerfile` AND `McpServerDockerfile.dockerignore`
