### PR TITLE
CMRNLP-152: Adds the ability to have authenticated tools

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.13"
 
@@ -44,10 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This section will contain examples, sample prompts, and advanced guides for LLM 
 Developer guidelines and procedures for contributing to and maintaining the application.
 
 - **[Adding a New Tool](developers/adding-a-new-tool.md)**: How to build and register a new tool, configure `manifest.json`, follow Semantic Versioning, and update Dockerfiles.
+- **[Adding Authentication to a Tool](developers/adding-authentication-to-a-tool.md)**: How to configure a tool to require authentication, including updating the manifest and handling OAuth scopes.
 - **[Adding an Environment Variable](developers/adding-an-env-var.md)**: The exact files to touch in Terraform, Docker, and Bamboo when adding a new environment variable to the ECS container.
 - **[Versioning Methodology](developers/versioning.md)**: Explains the decoupled versioning strategy between the MCP Server (`pyproject.toml`) and individual tools (`manifest.json`).
 - **[Troubleshooting Deployments](developers/troubleshooting-deployments.md)**: Step-by-step instructions for debugging a `503 Service Unavailable` error, finding AWS CloudWatch logs, and fixing crash loops.

--- a/docs/developers/adding-authentication-to-a-tool.md
+++ b/docs/developers/adding-authentication-to-a-tool.md
@@ -1,0 +1,26 @@
+# Adding Authentication to a Tool
+
+To add authentication to a tool, you need to update the tool's manifest to include the `require_auth` property.
+
+For example, your `manifest.json` might look like this:
+
+```json
+{
+  "name": "example_tool",
+  "version": "1.0.0",
+  "entry_function": "example_tool",
+  "require_auth": true <-- This indicates that the tool requires authentication.
+}
+```
+
+## Using the User's Access Token
+
+After adding the `require_auth` property to the manifest, you can use the user's access token within your tool by importing and calling the `get_access_token` function from `fastmcp.server.dependencies`. For example:
+
+```python
+from fastmcp.server.dependencies import get_access_token
+
+token = get_access_token()
+
+# Access token will be available at `token.token`
+```

--- a/loader.py
+++ b/loader.py
@@ -73,6 +73,11 @@ class ToolManifest:
         """Get the tool annotations from the manifest, returning empty dict if not specified."""
         return self.manifest.get("annotations", {})
 
+    @property
+    def require_auth(self) -> bool:
+        """Get the tool auth requirement from the manifest, returning False if not specified."""
+        return self.manifest.get("require_auth", False)
+
 
 def create_simple_tool(
     manifest_path: Path,
@@ -129,10 +134,13 @@ def create_simple_tool(
     return register
 
 
-def load_tools_from_directory(mcp, tools_dir="tools"):
+ToolsReturnType = dict[str, dict[str, ToolManifest]]
+def load_tools_from_directory(mcp, tools_dir="tools") -> ToolsReturnType:
     """Load all tools from the tools directory."""
     tools_dir = Path(tools_dir)
     loaded = []
+
+    manifests = {}
 
     for tool_folder in sorted(tools_dir.iterdir()):
         if not tool_folder.is_dir() or tool_folder.name.startswith((".", "__")):
@@ -148,6 +156,8 @@ def load_tools_from_directory(mcp, tools_dir="tools"):
             manifest = ToolManifest(tool_folder)
 
             tool_name = manifest.get("name")
+            manifest_require_auth = manifest.get("require_auth", False)
+            manifests[tool_name] = manifest_require_auth
             tool_entry = manifest.get("entry_function")
             if not tool_name:
                 raise ValueError("manifest.json missing 'name' field")
@@ -222,4 +232,4 @@ def load_tools_from_directory(mcp, tools_dir="tools"):
     logger.info("Loaded: %d tools", len(loaded))
     logger.info("%s\n", "=" * 50)
 
-    return {"loaded": loaded, "failed": []}
+    return {"loaded": loaded, "failed": [], "manifests": manifests}

--- a/loader.py
+++ b/loader.py
@@ -17,7 +17,6 @@ from util.langfuse import flush_langfuse, log_tool_call, trace_update
 
 logger = logging.getLogger(__name__)
 
-
 class ToolManifest:
     """Handles manifest loading with sensible defaults."""
 

--- a/loader.py
+++ b/loader.py
@@ -139,6 +139,7 @@ def load_tools_from_directory(mcp, tools_dir="tools") -> ToolsReturnType:
     tools_dir = Path(tools_dir)
     loaded = []
 
+    # Collection information about each manifest. Keyed by tool name, storing whether authentication is required.
     manifests = {}
 
     for tool_folder in sorted(tools_dir.iterdir()):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ readme = "README.md"
 
 requires-python = "==3.13.0"
 dependencies = [
-    "fastmcp>=3.2.0,<4.0.0",
+    "fastmcp>=4",
     "earthaccess==0.14.0",
-    "starlette==0.48.0",
+    "starlette>=1.6",
     "uvicorn==0.37.0",
     "e84-geoai-common==0.0.7",
     "natural-language-geocoding==0.1.2",

--- a/server.py
+++ b/server.py
@@ -36,7 +36,8 @@ PACKAGE_NAME = "earthdata-mcp"
 URS_HOST = os.environ.get("URS_HOST", "https://sit.urs.earthdata.nasa.gov")
 URS_CLIENT_ID = os.environ.get("URS_CLIENT_ID", "fake_client_id")
 URS_CLIENT_SECRET = os.environ.get("URS_CLIENT_SECRET", "fake_client_secret")
-MCP_HOST = os.environ.get("MCP_HOST", "http://localhost:5001")
+URS_JWKS_PATH = os.environ.get("URS_JWKS_PATH", "/.well-known/edl_sit_jwks.json")
+CMR_HOST = os.environ.get("CMR_HOST", "http://localhost:5001")
 MCP_PATH = "/mcp/v1"
 
 # Get server version from installed package metadata
@@ -48,7 +49,7 @@ except importlib.metadata.PackageNotFoundError:
 # Configure token verification for your provider
 # See the Token Verification guide for provider-specific setups
 token_verifier = JWTVerifier(
-    jwks_uri=URS_HOST + "/.well-known/edl_sit_jwks.json",
+    jwks_uri=URS_HOST + URS_JWKS_PATH,
     issuer=URS_HOST,
 )
 
@@ -66,9 +67,8 @@ auth = OAuthProxy(
     token_verifier=token_verifier,
 
     # Your FastMCP server's public URL
-    base_url=MCP_HOST + "/mcp/v1",
-
-    resource_base_url=MCP_HOST,
+    base_url=CMR_HOST + "/mcp/v1",
+    resource_base_url=CMR_HOST,
 
     # EDL handles the consent
     require_authorization_consent="external",
@@ -101,7 +101,7 @@ async def health(_request):
 
 middleware = list(auth.get_middleware())
 
-metadata_url = build_resource_metadata_url(AnyHttpUrl(f"{MCP_HOST}{MCP_PATH}"))
+metadata_url = build_resource_metadata_url(AnyHttpUrl(f"{CMR_HOST}{MCP_PATH}"))
 
 middleware.append(ASGIMiddleware(StepUpAuth, tool_manifests=manifests, resource_metadata_url=metadata_url))
 middleware.append(cors)

--- a/server.py
+++ b/server.py
@@ -36,7 +36,7 @@ PACKAGE_NAME = "earthdata-mcp"
 URS_HOST = os.environ.get("URS_HOST", "https://sit.urs.earthdata.nasa.gov")
 URS_CLIENT_ID = os.environ.get("URS_CLIENT_ID")
 URS_CLIENT_SECRET = os.environ.get("URS_CLIENT_SECRET")
-PUBLIC_URL = "http://localhost:5001"
+MCP_HOST = os.environ.get("MCP_HOST", "http://localhost:5001")
 MCP_PATH = "/mcp/v1"
 
 # Get server version from installed package metadata
@@ -66,11 +66,11 @@ auth = OAuthProxy(
     token_verifier=token_verifier,
 
     # Your FastMCP server's public URL
-    # base_url=PUBLIC_URL + "/mcp/v1",
-    base_url=PUBLIC_URL,
-    # issuer_url=PUBLIC_URL,
+    # base_url=MCP_HOST + "/mcp/v1",
+    base_url=MCP_HOST,
+    # issuer_url=MCP_HOST,
 
-    resource_base_url=PUBLIC_URL,
+    resource_base_url=MCP_HOST,
     redirect_path="/mcp/v1/auth/callback",
 
     # EDL handles the consent
@@ -104,7 +104,7 @@ async def health(_request):
 
 middleware = list(auth.get_middleware())
 
-metadata_url = build_resource_metadata_url(AnyHttpUrl(f"{PUBLIC_URL}{MCP_PATH}"))
+metadata_url = build_resource_metadata_url(AnyHttpUrl(f"{MCP_HOST}{MCP_PATH}"))
 
 middleware.append(ASGIMiddleware(StepUpAuth, tool_manifests=manifests, resource_metadata_url=metadata_url))
 middleware.append(cors)

--- a/server.py
+++ b/server.py
@@ -67,11 +67,8 @@ auth = OAuthProxy(
 
     # Your FastMCP server's public URL
     base_url=MCP_HOST + "/mcp/v1",
-    # base_url=MCP_HOST,
-    # issuer_url=MCP_HOST,
 
     resource_base_url=MCP_HOST,
-    # redirect_path="/mcp/v1/auth/callback",
 
     # EDL handles the consent
     require_authorization_consent="external",
@@ -111,29 +108,23 @@ middleware.append(cors)
 
 # Build the app with middleware and the intended path
 app = mcp.http_app(path=MCP_PATH, middleware=middleware)
-# app = mcp.http_app(path="/", middleware=middleware)
 
 auth_routes = auth.get_routes(mcp_path=MCP_PATH)
-# auth_routes = auth.get_routes()
-
-print(auth_routes)
 
 well_known = [route for route in auth_routes if route.path.startswith("/.well-known")]
 operational = [route for route in auth_routes if not route.path.startswith("/.well-known")]
 
 app.routes.extend(auth_routes)
-# app.routes.extend(well_known)
+
+# Mount the well-known OAuth authorization server route with the MCP path
 as_metadata = next(route for route in well_known if route.path == "/.well-known/oauth-authorization-server")
 app.routes.append(Route("/.well-known/oauth-authorization-server" + MCP_PATH, as_metadata.endpoint, methods=["GET", "OPTIONS"]))
 
+# Mount the operational routes under the /mcp/v1 path
 app.routes.append(Mount("/mcp/v1", routes=operational))
 
 # Add health check route
 app.routes.append(Route("/mcp/health", health))
-
-all_routes = app.routes
-print(all_routes)
-
 
 def main():
     """

--- a/server.py
+++ b/server.py
@@ -121,13 +121,10 @@ print(auth_routes)
 well_known = [route for route in auth_routes if route.path.startswith("/.well-known")]
 operational = [route for route in auth_routes if not route.path.startswith("/.well-known")]
 
-app.routes.extend(auth_routes)
+# app.routes.extend(auth_routes)
 app.routes.extend(well_known)
-as_metadata = next(route for route in well_known if route.path == "/.well-known/oauth-authorization-server")
-app.routes.append(Route("/.well-known/oauth-authorization-server/mcp", as_metadata.endpoint, methods=["GET", "OPTIONS"]))
-
-# register_metadata = next(route for route in operational if route.path == "/register")
-# app.routes.append(Route("/mcp/v1/register", register_metadata.endpoint, methods=["GET", "OPTIONS"]))
+# as_metadata = next(route for route in well_known if route.path == "/.well-known/oauth-authorization-server")
+# app.routes.append(Route("/.well-known/oauth-authorization-server/mcp", as_metadata.endpoint, methods=["GET", "OPTIONS"]))
 
 app.routes.append(Mount("/mcp/v1", routes=operational))
 

--- a/server.py
+++ b/server.py
@@ -8,11 +8,18 @@ import sys
 import uvicorn
 from dotenv import load_dotenv
 from fastmcp import FastMCP
+from fastmcp.server.auth import OAuthProxy
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+from starlette.middleware import Middleware as ASGIMiddleware
 from starlette.responses import JSONResponse
 from starlette.routing import Route
+from mcp.server.auth.routes import build_resource_metadata_url
+
+from pydantic import AnyHttpUrl
 from loader import load_tools_from_directory
 from middleware import get_cors_middleware
 from prompts.instructions import MCP_SERVER_INSTRUCTIONS
+from util.stepup import StepUpAuth
 
 load_dotenv()
 
@@ -26,11 +33,51 @@ logging.basicConfig(
 
 PACKAGE_NAME = "earthdata-mcp"
 
+URS_HOST = os.environ.get("URS_HOST", "https://sit.urs.earthdata.nasa.gov")
+URS_CLIENT_ID = os.environ.get("URS_CLIENT_ID")
+URS_CLIENT_SECRET = os.environ.get("URS_CLIENT_SECRET")
+PUBLIC_URL = "http://localhost:5001"
+MCP_PATH = "/mcp/v1"
+
 # Get server version from installed package metadata
 try:
     server_version = importlib.metadata.version(PACKAGE_NAME)
 except importlib.metadata.PackageNotFoundError:
     server_version = "dev"
+
+# Configure token verification for your provider
+# See the Token Verification guide for provider-specific setups
+token_verifier = JWTVerifier(
+    jwks_uri=URS_HOST + "/.well-known/edl_sit_jwks.json",
+    issuer=URS_HOST,
+)
+
+# Create the OAuth proxy
+auth = OAuthProxy(
+    # Provider's OAuth endpoints (from their documentation)
+    upstream_authorization_endpoint=URS_HOST + "/oauth/authorize",
+    upstream_token_endpoint=URS_HOST + "/oauth/token",
+
+    # Your registered app credentials
+    upstream_client_id=URS_CLIENT_ID,
+    upstream_client_secret=URS_CLIENT_SECRET,
+
+    # Token validation (see Token Verification guide)
+    token_verifier=token_verifier,
+
+    # Your FastMCP server's public URL
+    # base_url=PUBLIC_URL + "/mcp/v1",
+    base_url=PUBLIC_URL,
+    # issuer_url=PUBLIC_URL,
+
+    resource_base_url=PUBLIC_URL,
+    redirect_path="/mcp/v1/auth/callback",
+
+    # EDL handles the consent
+    require_authorization_consent="external",
+    # Do not forward the resource to the upstream provider
+    forward_resource=False,
+)
 
 # Initialize FastMCP server
 mcp = FastMCP(
@@ -42,7 +89,8 @@ cors = get_cors_middleware()
 
 try:
     # Load tool plugins
-    load_tools_from_directory(mcp)
+    result = load_tools_from_directory(mcp)
+    manifests = result.get("manifests", [])
     logger.info("Successfully loaded tools from directory")
 except Exception as e:
     logger.error("Failed to load tools: %s", e)
@@ -54,9 +102,23 @@ async def health(_request):
     """Health check endpoint for load balancer."""
     return JSONResponse({"earthdata-mcp": {"ok?": True}})
 
+middleware = list(auth.get_middleware())
+
+metadata_url = build_resource_metadata_url(AnyHttpUrl(f"{PUBLIC_URL}{MCP_PATH}"))
+
+middleware.append(ASGIMiddleware(StepUpAuth, tool_manifests=manifests, resource_metadata_url=metadata_url))
+middleware.append(cors)
 
 # Build the app with middleware and the intended path
-app = mcp.http_app(path="/mcp/v1", middleware=[cors])
+app = mcp.http_app(path=MCP_PATH, middleware=middleware)
+# app = mcp.http_app(path="/", middleware=middleware)
+
+auth_routes = auth.get_routes(mcp_path=MCP_PATH)
+# auth_routes = auth.get_routes()
+
+print(auth_routes)
+
+app.routes.extend(auth_routes)
 
 # Add health check route
 app.routes.append(Route("/mcp/health", health))

--- a/server.py
+++ b/server.py
@@ -67,7 +67,7 @@ auth = OAuthProxy(
     token_verifier=token_verifier,
 
     # Your FastMCP server's public URL
-    base_url=CMR_HOST + "/mcp/v1",
+    base_url=CMR_HOST + MCP_PATH,
     resource_base_url=CMR_HOST,
 
     # EDL handles the consent
@@ -120,8 +120,8 @@ app.routes.extend(auth_routes)
 as_metadata = next(route for route in well_known if route.path == "/.well-known/oauth-authorization-server")
 app.routes.append(Route("/.well-known/oauth-authorization-server" + MCP_PATH, as_metadata.endpoint, methods=["GET", "OPTIONS"]))
 
-# Mount the operational routes under the /mcp/v1 path
-app.routes.append(Mount("/mcp/v1", routes=operational))
+# Mount the operational routes under the MCP_PATH
+app.routes.append(Mount(MCP_PATH, routes=operational))
 
 # Add health check route
 app.routes.append(Route("/mcp/health", health))

--- a/server.py
+++ b/server.py
@@ -70,7 +70,7 @@ auth = OAuthProxy(
     # base_url=MCP_HOST,
     issuer_url=MCP_HOST,
 
-    resource_base_url=MCP_HOST,
+    # resource_base_url=MCP_HOST,
     # redirect_path="/mcp/v1/auth/callback",
 
     # EDL handles the consent
@@ -125,6 +125,10 @@ app.routes.extend(auth_routes)
 app.routes.extend(well_known)
 as_metadata = next(route for route in well_known if route.path == "/.well-known/oauth-authorization-server")
 app.routes.append(Route("/.well-known/oauth-authorization-server/mcp", as_metadata.endpoint, methods=["GET", "OPTIONS"]))
+
+# register_metadata = next(route for route in operational if route.path == "/register")
+# app.routes.append(Route("/mcp/v1/register", register_metadata.endpoint, methods=["GET", "OPTIONS"]))
+
 app.routes.append(Mount("/mcp/v1", routes=operational))
 
 # Add health check route

--- a/server.py
+++ b/server.py
@@ -70,7 +70,7 @@ auth = OAuthProxy(
     # base_url=MCP_HOST,
     issuer_url=MCP_HOST,
 
-    # resource_base_url=MCP_HOST,
+    resource_base_url=MCP_HOST,
     # redirect_path="/mcp/v1/auth/callback",
 
     # EDL handles the consent

--- a/server.py
+++ b/server.py
@@ -12,7 +12,7 @@ from fastmcp.server.auth import OAuthProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from starlette.middleware import Middleware as ASGIMiddleware
 from starlette.responses import JSONResponse
-from starlette.routing import Route
+from starlette.routing import Mount, Route
 from mcp.server.auth.routes import build_resource_metadata_url
 
 from pydantic import AnyHttpUrl
@@ -66,12 +66,12 @@ auth = OAuthProxy(
     token_verifier=token_verifier,
 
     # Your FastMCP server's public URL
-    # base_url=MCP_HOST + "/mcp/v1",
-    base_url=MCP_HOST,
-    # issuer_url=MCP_HOST,
+    base_url=MCP_HOST + "/mcp/v1",
+    # base_url=MCP_HOST,
+    issuer_url=MCP_HOST,
 
     resource_base_url=MCP_HOST,
-    redirect_path="/mcp/v1/auth/callback",
+    # redirect_path="/mcp/v1/auth/callback",
 
     # EDL handles the consent
     require_authorization_consent="external",
@@ -118,10 +118,20 @@ auth_routes = auth.get_routes(mcp_path=MCP_PATH)
 
 print(auth_routes)
 
+well_known = [route for route in auth_routes if route.path.startswith("/.well-known")]
+operational = [route for route in auth_routes if not route.path.startswith("/.well-known")]
+
 app.routes.extend(auth_routes)
+app.routes.extend(well_known)
+as_metadata = next(route for route in well_known if route.path == "/.well-known/oauth-authorization-server")
+app.routes.append(Route("/.well-known/oauth-authorization-server/mcp", as_metadata.endpoint, methods=["GET", "OPTIONS"]))
+app.routes.append(Mount("/mcp/v1", routes=operational))
 
 # Add health check route
 app.routes.append(Route("/mcp/health", health))
+
+all_routes = app.routes
+print(all_routes)
 
 
 def main():

--- a/server.py
+++ b/server.py
@@ -68,7 +68,7 @@ auth = OAuthProxy(
     # Your FastMCP server's public URL
     base_url=MCP_HOST + "/mcp/v1",
     # base_url=MCP_HOST,
-    issuer_url=MCP_HOST,
+    # issuer_url=MCP_HOST,
 
     resource_base_url=MCP_HOST,
     # redirect_path="/mcp/v1/auth/callback",
@@ -121,10 +121,10 @@ print(auth_routes)
 well_known = [route for route in auth_routes if route.path.startswith("/.well-known")]
 operational = [route for route in auth_routes if not route.path.startswith("/.well-known")]
 
-# app.routes.extend(auth_routes)
-app.routes.extend(well_known)
-# as_metadata = next(route for route in well_known if route.path == "/.well-known/oauth-authorization-server")
-# app.routes.append(Route("/.well-known/oauth-authorization-server/mcp", as_metadata.endpoint, methods=["GET", "OPTIONS"]))
+app.routes.extend(auth_routes)
+# app.routes.extend(well_known)
+as_metadata = next(route for route in well_known if route.path == "/.well-known/oauth-authorization-server")
+app.routes.append(Route("/.well-known/oauth-authorization-server" + MCP_PATH, as_metadata.endpoint, methods=["GET", "OPTIONS"]))
 
 app.routes.append(Mount("/mcp/v1", routes=operational))
 

--- a/server.py
+++ b/server.py
@@ -34,8 +34,8 @@ logging.basicConfig(
 PACKAGE_NAME = "earthdata-mcp"
 
 URS_HOST = os.environ.get("URS_HOST", "https://sit.urs.earthdata.nasa.gov")
-URS_CLIENT_ID = os.environ.get("URS_CLIENT_ID")
-URS_CLIENT_SECRET = os.environ.get("URS_CLIENT_SECRET")
+URS_CLIENT_ID = os.environ.get("URS_CLIENT_ID", "fake_client_id")
+URS_CLIENT_SECRET = os.environ.get("URS_CLIENT_SECRET", "fake_client_secret")
 MCP_HOST = os.environ.get("MCP_HOST", "http://localhost:5001")
 MCP_PATH = "/mcp/v1"
 

--- a/terraform/application/main.tf
+++ b/terraform/application/main.tf
@@ -95,5 +95,9 @@ module "application" {
   # Tool associations
   tool_assoc_max_workers = var.tool_assoc_max_workers
 
+  urs_host          = var.urs_host
+  urs_client_id     = var.urs_client_id
+  urs_client_secret = var.urs_client_secret
+
   tags = var.tags
 }

--- a/terraform/application/main.tf
+++ b/terraform/application/main.tf
@@ -95,6 +95,7 @@ module "application" {
   # Tool associations
   tool_assoc_max_workers = var.tool_assoc_max_workers
 
+  mcp_host          = var.mcp_host
   urs_host          = var.urs_host
   urs_client_id     = var.urs_client_id
   urs_client_secret = var.urs_client_secret

--- a/terraform/application/main.tf
+++ b/terraform/application/main.tf
@@ -95,10 +95,11 @@ module "application" {
   # Tool associations
   tool_assoc_max_workers = var.tool_assoc_max_workers
 
-  mcp_host          = var.mcp_host
+  cmr_host          = var.cmr_host
   urs_host          = var.urs_host
   urs_client_id     = var.urs_client_id
   urs_client_secret = var.urs_client_secret
+  urs_jwks_path     = var.urs_jwks_path
 
   tags = var.tags
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -194,8 +194,8 @@ variable "tool_assoc_max_workers" {
   default     = "10"
 }
 
-variable "mcp_host" {
-  description = "MCP host URL"
+variable "cmr_host" {
+  description = "CMR host URL"
   type        = string
   default     = "http://localhost:5001"
 }
@@ -216,4 +216,10 @@ variable "urs_client_secret" {
   description = "URS client secret"
   type        = string
   default     = ""
+}
+
+variable "urs_jwks_path" {
+  description = "Path to the URS JWKS file"
+  type        = string
+  default     = "/.well-known/edl_sit_jwks.json"
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -193,3 +193,21 @@ variable "tool_assoc_max_workers" {
   type        = string
   default     = "10"
 }
+
+variable "urs_host" {
+  description = "URS host URL"
+  type        = string
+  default     = "https://sit.urs.earthdata.nasa.gov"
+}
+
+variable "urs_client_id" {
+  description = "URS client ID"
+  type        = string
+  default     = ""
+}
+
+variable "urs_client_secret" {
+  description = "URS client secret"
+  type        = string
+  default     = ""
+}

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -194,6 +194,12 @@ variable "tool_assoc_max_workers" {
   default     = "10"
 }
 
+variable "mcp_host" {
+  description = "MCP host URL"
+  type        = string
+  default     = "http://localhost:5001"
+}
+
 variable "urs_host" {
   description = "URS host URL"
   type        = string

--- a/terraform/modules/application/mcp-server.tf
+++ b/terraform/modules/application/mcp-server.tf
@@ -187,7 +187,7 @@ resource "aws_lb_listener_rule" "mcp" {
 
   condition {
     path_pattern {
-      values = ["/mcp", "/mcp/*", "/.well-known/oauth-authorization-server/mcp*"]
+      values = ["/mcp", "/mcp/*", "/.well-known/*/mcp*"]
     }
   }
 

--- a/terraform/modules/application/mcp-server.tf
+++ b/terraform/modules/application/mcp-server.tf
@@ -264,6 +264,18 @@ resource "aws_ecs_task_definition" "mcp" {
         {
           name  = "TOOL_ASSOC_MAX_WORKERS"
           value = var.tool_assoc_max_workers
+        },
+        {
+          name  = "URS_HOST"
+          value = var.urs_host
+        },
+        {
+          name  = "URS_CLIENT_ID"
+          value = var.urs_client_id
+        },
+        {
+          name  = "URS_CLIENT_SECRET"
+          value = var.urs_client_secret
         }
       ]
 

--- a/terraform/modules/application/mcp-server.tf
+++ b/terraform/modules/application/mcp-server.tf
@@ -187,7 +187,7 @@ resource "aws_lb_listener_rule" "mcp" {
 
   condition {
     path_pattern {
-      values = ["/mcp", "/mcp/*"]
+      values = ["/mcp", "/mcp/*", "/.well-known/*/mcp", "/.well-known/*/mcp/*"]
     }
   }
 

--- a/terraform/modules/application/mcp-server.tf
+++ b/terraform/modules/application/mcp-server.tf
@@ -187,7 +187,7 @@ resource "aws_lb_listener_rule" "mcp" {
 
   condition {
     path_pattern {
-      values = ["/mcp", "/mcp/*", "*mcp*", ".well-known/oauth-authorization-server/mcp"]
+      values = ["/mcp", "/mcp/*", "/.well-known/oauth-authorization-server"]
     }
   }
 

--- a/terraform/modules/application/mcp-server.tf
+++ b/terraform/modules/application/mcp-server.tf
@@ -266,6 +266,10 @@ resource "aws_ecs_task_definition" "mcp" {
           value = var.tool_assoc_max_workers
         },
         {
+          name  = "MCP_HOST"
+          value = var.mcp_host
+        },
+        {
           name  = "URS_HOST"
           value = var.urs_host
         },

--- a/terraform/modules/application/mcp-server.tf
+++ b/terraform/modules/application/mcp-server.tf
@@ -266,8 +266,8 @@ resource "aws_ecs_task_definition" "mcp" {
           value = var.tool_assoc_max_workers
         },
         {
-          name  = "MCP_HOST"
-          value = var.mcp_host
+          name  = "CMR_HOST"
+          value = var.cmr_host
         },
         {
           name  = "URS_HOST"
@@ -280,6 +280,10 @@ resource "aws_ecs_task_definition" "mcp" {
         {
           name  = "URS_CLIENT_SECRET"
           value = var.urs_client_secret
+        },
+        {
+          name  = "URS_JWKS_PATH"
+          value = var.urs_jwks_path
         }
       ]
 

--- a/terraform/modules/application/mcp-server.tf
+++ b/terraform/modules/application/mcp-server.tf
@@ -187,7 +187,7 @@ resource "aws_lb_listener_rule" "mcp" {
 
   condition {
     path_pattern {
-      values = ["/mcp", "/mcp/*", "/.well-known/oauth-authorization-server"]
+      values = ["/mcp", "/mcp/*", "/.well-known/oauth-authorization-server/mcp*"]
     }
   }
 

--- a/terraform/modules/application/mcp-server.tf
+++ b/terraform/modules/application/mcp-server.tf
@@ -187,7 +187,7 @@ resource "aws_lb_listener_rule" "mcp" {
 
   condition {
     path_pattern {
-      values = ["/mcp", "/mcp/*", "/.well-known/*/mcp", "/.well-known/*/mcp/*"]
+      values = ["/mcp", "/mcp/*", "*mcp*", ".well-known/oauth-authorization-server/mcp"]
     }
   }
 

--- a/terraform/modules/application/variables.tf
+++ b/terraform/modules/application/variables.tf
@@ -172,6 +172,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "mcp_host" {
+  description = "MCP host URL"
+  type        = string
+  default     = "http://localhost:5001"
+}
+
 variable "urs_host" {
   description = "URS host URL"
   type        = string

--- a/terraform/modules/application/variables.tf
+++ b/terraform/modules/application/variables.tf
@@ -171,3 +171,21 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "urs_host" {
+  description = "URS host URL"
+  type        = string
+  default     = "https://sit.urs.earthdata.nasa.gov"
+}
+
+variable "urs_client_id" {
+  description = "URS client ID"
+  type        = string
+  default     = ""
+}
+
+variable "urs_client_secret" {
+  description = "URS client secret"
+  type        = string
+  default     = ""
+}

--- a/terraform/modules/application/variables.tf
+++ b/terraform/modules/application/variables.tf
@@ -172,8 +172,8 @@ variable "tags" {
   default     = {}
 }
 
-variable "mcp_host" {
-  description = "MCP host URL"
+variable "cmr_host" {
+  description = "CMR host URL"
   type        = string
   default     = "http://localhost:5001"
 }
@@ -194,4 +194,10 @@ variable "urs_client_secret" {
   description = "URS client secret"
   type        = string
   default     = ""
+}
+
+variable "urs_jwks_path" {
+  description = "Path to the URS JWKS file"
+  type        = string
+  default     = "/.well-known/edl_sit_jwks.json"
 }

--- a/terraform/scripts/bamboo/deploy-application.sh
+++ b/terraform/scripts/bamboo/deploy-application.sh
@@ -36,6 +36,7 @@ set -e
 # | bamboo_SIMPLIFY_GEOM_MAX_POINT  | No       | 4900                           |
 # | bamboo_EMBEDDING_LAMBDA_CONCURRENCY   | No | 10                             |
 # | bamboo_ENRICHMENT_LAMBDA_CONCURRENCY  | No | 500                            |
+# | bamboo_MCP_HOST                 | No       | http://localhost:5001          |
 # | bamboo_URS_HOST                 | No       | https://sit.urs.earthdata.nasa.gov |
 # | bamboo_URS_CLIENT_ID            | No       |                                |
 # | bamboo_URS_CLIENT_SECRET        | No       |                                |
@@ -78,6 +79,7 @@ export TF_VAR_load_balancer_name="${bamboo_LOAD_BALANCER_NAME}"
 [ -n "$bamboo_GEOCODE_INDEX_PORT" ] && export TF_VAR_geocode_index_port="$bamboo_GEOCODE_INDEX_PORT"
 [ -n "$bamboo_SIMPLIFY_GEOM_MAX_POINT" ] && export TF_VAR_simplify_geom_max_point="$bamboo_SIMPLIFY_GEOM_MAX_POINT"
 
+[ -n "$bamboo_MCP_HOST" ] && export TF_VAR_mcp_host="$bamboo_MCP_HOST"
 [ -n "$bamboo_URS_HOST" ] && export TF_VAR_urs_host="$bamboo_URS_HOST"
 [ -n "$bamboo_URS_CLIENT_ID" ] && export TF_VAR_urs_client_id="$bamboo_URS_CLIENT_ID"
 [ -n "$bamboo_URS_CLIENT_SECRET" ] && export TF_VAR_urs_client_secret="$bamboo_URS_CLIENT_SECRET"

--- a/terraform/scripts/bamboo/deploy-application.sh
+++ b/terraform/scripts/bamboo/deploy-application.sh
@@ -36,10 +36,11 @@ set -e
 # | bamboo_SIMPLIFY_GEOM_MAX_POINT  | No       | 4900                           |
 # | bamboo_EMBEDDING_LAMBDA_CONCURRENCY   | No | 10                             |
 # | bamboo_ENRICHMENT_LAMBDA_CONCURRENCY  | No | 500                            |
-# | bamboo_MCP_HOST                 | No       | http://localhost:5001          |
+# | bamboo_CMR_HOST                 | No       | http://localhost:5001          |
 # | bamboo_URS_HOST                 | No       | https://sit.urs.earthdata.nasa.gov |
 # | bamboo_URS_CLIENT_ID            | No       |                                |
 # | bamboo_URS_CLIENT_SECRET        | No       |                                |
+# | bamboo_URS_JWKS_PATH            | No       | /.well-known/edl_sit_jwks.json |
 # +---------------------------------+----------+--------------------------------+
 
 # Set AWS credentials from Bamboo variables
@@ -79,10 +80,11 @@ export TF_VAR_load_balancer_name="${bamboo_LOAD_BALANCER_NAME}"
 [ -n "$bamboo_GEOCODE_INDEX_PORT" ] && export TF_VAR_geocode_index_port="$bamboo_GEOCODE_INDEX_PORT"
 [ -n "$bamboo_SIMPLIFY_GEOM_MAX_POINT" ] && export TF_VAR_simplify_geom_max_point="$bamboo_SIMPLIFY_GEOM_MAX_POINT"
 
-[ -n "$bamboo_MCP_HOST" ] && export TF_VAR_mcp_host="$bamboo_MCP_HOST"
+[ -n "$bamboo_CMR_HOST" ] && export TF_VAR_cmr_host="$bamboo_CMR_HOST"
 [ -n "$bamboo_URS_HOST" ] && export TF_VAR_urs_host="$bamboo_URS_HOST"
 [ -n "$bamboo_URS_CLIENT_ID" ] && export TF_VAR_urs_client_id="$bamboo_URS_CLIENT_ID"
 [ -n "$bamboo_URS_CLIENT_SECRET" ] && export TF_VAR_urs_client_secret="$bamboo_URS_CLIENT_SECRET"
+[ -n "$bamboo_URS_JWKS_PATH" ] && export TF_VAR_urs_jwks_path="$bamboo_URS_JWKS_PATH"
 
 # Store Langfuse secret in SSM SecureString if provided
 if [ -n "$bamboo_LANGFUSE_SECRET_KEY" ]; then

--- a/terraform/scripts/bamboo/deploy-application.sh
+++ b/terraform/scripts/bamboo/deploy-application.sh
@@ -36,6 +36,9 @@ set -e
 # | bamboo_SIMPLIFY_GEOM_MAX_POINT  | No       | 4900                           |
 # | bamboo_EMBEDDING_LAMBDA_CONCURRENCY   | No | 10                             |
 # | bamboo_ENRICHMENT_LAMBDA_CONCURRENCY  | No | 500                            |
+# | bamboo_URS_HOST                 | No       | https://sit.urs.earthdata.nasa.gov |
+# | bamboo_URS_CLIENT_ID            | No       |                                |
+# | bamboo_URS_CLIENT_SECRET        | No       |                                |
 # +---------------------------------+----------+--------------------------------+
 
 # Set AWS credentials from Bamboo variables
@@ -74,6 +77,10 @@ export TF_VAR_load_balancer_name="${bamboo_LOAD_BALANCER_NAME}"
 [ -n "$bamboo_GEOCODE_INDEX_REGION" ] && export TF_VAR_geocode_index_region="$bamboo_GEOCODE_INDEX_REGION"
 [ -n "$bamboo_GEOCODE_INDEX_PORT" ] && export TF_VAR_geocode_index_port="$bamboo_GEOCODE_INDEX_PORT"
 [ -n "$bamboo_SIMPLIFY_GEOM_MAX_POINT" ] && export TF_VAR_simplify_geom_max_point="$bamboo_SIMPLIFY_GEOM_MAX_POINT"
+
+[ -n "$bamboo_URS_HOST" ] && export TF_VAR_urs_host="$bamboo_URS_HOST"
+[ -n "$bamboo_URS_CLIENT_ID" ] && export TF_VAR_urs_client_id="$bamboo_URS_CLIENT_ID"
+[ -n "$bamboo_URS_CLIENT_SECRET" ] && export TF_VAR_urs_client_secret="$bamboo_URS_CLIENT_SECRET"
 
 # Store Langfuse secret in SSM SecureString if provided
 if [ -n "$bamboo_LANGFUSE_SECRET_KEY" ]; then

--- a/tools/get_collections/manifest.json
+++ b/tools/get_collections/manifest.json
@@ -19,6 +19,7 @@
         "idempotentHint": true,
         "openWorldHint": true
     },
+    "require_auth": true,
     "examples": {
         "keyword_search": {
             "description": "Search collections by keyword",

--- a/tools/get_collections/manifest.json
+++ b/tools/get_collections/manifest.json
@@ -19,7 +19,6 @@
         "idempotentHint": true,
         "openWorldHint": true
     },
-    "require_auth": true,
     "examples": {
         "keyword_search": {
             "description": "Search collections by keyword",

--- a/util/stepup.py
+++ b/util/stepup.py
@@ -34,22 +34,19 @@ class StepUpAuth:
 
         body, receive = await _buffer_body(receive)
         name = _called_tool(body)
-        logger.info(f"StepUpAuth: called tool '{name}'")
-        logger.info(f"StepUpAuth: self.tool_manifests = {self.tool_manifests}")
-        tool_auth = self.tool_manifests.get(name, False)
-        logger.info(f"StepUpAuth: tool_auth = {tool_auth}")
-        if tool_auth is False:
-            logger.info(f"StepUpAuth: tool '{name}' does not require auth")
+        tool_requires_auth = self.tool_manifests.get(name, False)
+
+        # If the tool does not require authentication, proceed with the request.
+        if tool_requires_auth is False:
             return await self.app(scope, receive, send)
 
         user = scope.get("user")
         token = user.access_token if isinstance(user, AuthenticatedUser) else None
+
+        # If the token exists, proceed with the request.
         if token is not None:
             return await self.app(scope, receive, send)
 
-        status = "401 (no valid token)" if token is None else "403 insufficient_scope"
-
-        logger.info(f"StepUpAuth: HTTP {status} challenge for tool '{name}'")
         # Reuse the framework's own enforcement for the response. It picks 401 vs 403 and
         # builds the WWW-Authenticate header (resource_metadata=..., scope=...).
         gate = RequireAuthMiddleware(
@@ -57,6 +54,8 @@ class StepUpAuth:
             required_scopes=[],
             resource_metadata_url=self.resource_metadata_url,
         )
+
+        # Redirect the request to the RequireAuthMiddleware to enforce authentication.
         await gate(scope, receive, send)
 
 

--- a/util/stepup.py
+++ b/util/stepup.py
@@ -1,0 +1,92 @@
+"""HTTP-layer step-up: turn a failed per-tool check into an HTTP 401/403 challenge.
+
+This runs BEFORE the MCP transport sees the request, which is the only place an
+HTTP status can be chosen. An MCP client that receives 401 + WWW-Authenticate
+starts its OAuth flow and then retries the same tools/call.
+
+ASGI stack, outermost first:
+  AuthenticationMiddleware(BearerAuthBackend)  parses Authorization -> scope["user"]   (never rejects)
+  AuthContextMiddleware                        exposes the token to tool code           (never rejects)
+  StepUpAuth (this file)                       per-tool challenge for protected tools
+  streamable-HTTP MCP endpoint
+"""
+
+import json
+import logging
+
+from fastmcp.server.auth import AuthContext
+from fastmcp.server.auth.middleware import RequireAuthMiddleware
+from fastmcp.server.auth import require_scopes
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+
+logger = logging.getLogger(__name__)
+
+
+class StepUpAuth:
+    def __init__(self, app, *, tool_manifests, resource_metadata_url):
+        self.app = app
+        self.tool_manifests = tool_manifests  # tool name -> AuthCheck (must expose .scopes and .label)
+        self.resource_metadata_url = resource_metadata_url
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http" or scope["method"] != "POST":
+            return await self.app(scope, receive, send)
+
+        body, receive = await _buffer_body(receive)
+        name = _called_tool(body)
+        logger.info(f"StepUpAuth: called tool '{name}'")
+        logger.info(f"StepUpAuth: self.tool_manifests = {self.tool_manifests}")
+        tool_auth = self.tool_manifests.get(name, False)
+        logger.info(f"StepUpAuth: tool_auth = {tool_auth}")
+        if tool_auth is False:
+            logger.info(f"StepUpAuth: tool '{name}' does not require auth")
+            return await self.app(scope, receive, send)
+
+        user = scope.get("user")
+        token = user.access_token if isinstance(user, AuthenticatedUser) else None
+        if token is not None:
+            return await self.app(scope, receive, send)
+
+        status = "401 (no valid token)" if token is None else "403 insufficient_scope"
+
+        logger.info(f"StepUpAuth: HTTP {status} challenge for tool '{name}'")
+        # Reuse the framework's own enforcement for the response. It picks 401 vs 403 and
+        # builds the WWW-Authenticate header (resource_metadata=..., scope=...).
+        gate = RequireAuthMiddleware(
+            self.app,
+            required_scopes=[],
+            resource_metadata_url=self.resource_metadata_url,
+        )
+        await gate(scope, receive, send)
+
+
+async def _buffer_body(receive):
+    """Read the whole request body, then hand back a receive() that replays it."""
+    chunks, more = [], True
+    while more:
+        message = await receive()
+        chunks.append(message.get("body", b""))
+        more = message.get("more_body", False)
+    body = b"".join(chunks)
+    replayed = False
+
+    async def replay():
+        nonlocal replayed
+        if replayed:
+            return await receive()
+        replayed = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return body, replay
+
+
+def _called_tool(body: bytes) -> str | None:
+    """Tool name if the JSON-RPC body is a tools/call, else None."""
+    try:
+        parsed = json.loads(body)
+    except ValueError:
+        return None
+    for msg in parsed if isinstance(parsed, list) else [parsed]:
+        if isinstance(msg, dict) and msg.get("method") == "tools/call":
+            return (msg.get("params") or {}).get("name")
+    return None

--- a/util/stepup.py
+++ b/util/stepup.py
@@ -14,15 +14,15 @@ ASGI stack, outermost first:
 import json
 import logging
 
-from fastmcp.server.auth import AuthContext
 from fastmcp.server.auth.middleware import RequireAuthMiddleware
-from fastmcp.server.auth import require_scopes
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 
 logger = logging.getLogger(__name__)
 
 
 class StepUpAuth:
+    """Per-tool step-up authentication middleware for MCP server."""
+
     def __init__(self, app, *, tool_manifests, resource_metadata_url):
         self.app = app
         self.tool_manifests = tool_manifests  # tool name -> AuthCheck (must expose .scopes and .label)

--- a/uv.lock
+++ b/uv.lock
@@ -582,7 +582,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.28.0" },
     { name = "e84-geoai-common", specifier = "==0.0.7" },
     { name = "earthaccess", specifier = "==0.14.0" },
-    { name = "fastmcp", specifier = ">=3.2.0,<4.0.0" },
+    { name = "fastmcp", specifier = ">=4" },
     { name = "jsonpath-ng", specifier = ">=1.7.0" },
     { name = "jsonschema", specifier = ">=4.17.3" },
     { name = "langfuse", specifier = "==3.10.6" },
@@ -598,7 +598,7 @@ requires-dist = [
     { name = "python-toon", specifier = "==0.1.3" },
     { name = "responses", marker = "extra == 'dev'", specifier = "==0.25.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.8.6" },
-    { name = "starlette", specifier = "==0.48.0" },
+    { name = "starlette", specifier = ">=1.6" },
     { name = "uvicorn", specifier = "==0.37.0" },
 ]
 provides-extras = ["dev"]
@@ -644,21 +644,22 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.0"
+version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/24/519739e98daf92ebc64580e9d3320649bf9a1612c029a913dd88c3474d73/fastmcp-3.4.0.tar.gz", hash = "sha256:29055fb6816f4862c615aabaf0112ae8feb8b469740db13403a0ce5b799ec1dc", size = 28754939, upload-time = "2026-06-03T02:32:40.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/1a/bee10aff530338f3b8982a3dd1c377c3ba5d0bc724615bf358422c4e9ecf/fastmcp-4.0.3.tar.gz", hash = "sha256:0dd50baf070105ee4436c245f087ac3c047e655c32d9e783de16d0bf15783a98", size = 42311418, upload-time = "2026-09-05T00:31:36.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/72/9f9bbfc3a8d26870dbdbbd633cd1c6f42b8d3bec379426c760676d936e86/fastmcp-3.4.0-py3-none-any.whl", hash = "sha256:34523083d6149400a0655a8aa769eb34f85b1ce6dac6d66efb07503ebbe5f44b", size = 8017, upload-time = "2026-06-03T02:32:38.05Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/66600db497b3be21cf141f01296308169859d48ed9b1bc8ba7c9d83279b7/fastmcp-4.0.3-py3-none-any.whl", hash = "sha256:f743f43193e1daf606e6497a9dddba5bbaad7df7957a98fd093716ecf4458b99", size = 8076, upload-time = "2026-09-05T00:31:33.957Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.0"
+version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "mcp-types" },
     { name = "platformdirs" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
@@ -666,26 +667,27 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/b0/4da6078c2d6aa0a38a8b1ae0271e1ed400f9e2cd1b3b46e6453fb1fe2b75/fastmcp_slim-3.4.0.tar.gz", hash = "sha256:faa0ccf16e85ec4b9f79c006fed3546b866d7e6dba3f60cd32cd98e84753a496", size = 575895, upload-time = "2026-06-03T02:32:18.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/a9/b7b796b0d4a5e095dadef233833c82ac1136f5c110dd9947b2e9a4988518/fastmcp_slim-4.0.3.tar.gz", hash = "sha256:3ce04a82b82cc41ccb12bb3bb366cfd65b52bc797b8fee332a75da9d480f9b74", size = 685704, upload-time = "2026-09-05T00:31:12.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/66/cc283d4efd3faf325c26f51cfb43a118270ea732e70dda509f49d80ea625/fastmcp_slim-3.4.0-py3-none-any.whl", hash = "sha256:17cd0a1535972d3748d8c2416f0826dfc86c18df7a6cbc38602373277d44baa6", size = 748849, upload-time = "2026-06-03T02:32:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/43/4b/6b31820d87f56d5773538860878c8634b618cd1e9044b3bfbd8a78380a0f/fastmcp_slim-4.0.3-py3-none-any.whl", hash = "sha256:3756ed4bd9f82f40adaf51974b7cdd1463ab6b9f479cf69b69b2692969312b87", size = 859717, upload-time = "2026-09-05T00:31:10.93Z" },
 ]
 
 [package.optional-dependencies]
 client = [
     { name = "authlib" },
     { name = "exceptiongroup" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
 ]
 server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "griffelib" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
@@ -697,6 +699,7 @@ server = [
     { name = "pyperclip" },
     { name = "python-multipart" },
     { name = "pyyaml" },
+    { name = "starlette" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
@@ -861,15 +864,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
-]
-
-[[package]]
-name = "httpx-sse"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -1190,15 +1184,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1208,9 +1202,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/31/ac54fb0fdd5b37de704486e288bba4fbbb463f24cfcfedbede407b854513/mcp-2.2.0.tar.gz", hash = "sha256:2dc37ecb1974becdcebdbf7561e7c15a07dbbf20ba21ba16c3593b3038b3afbd", size = 4084129, upload-time = "2026-09-07T16:06:23.439Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ff/8e7eade68b8a28f7da0ed1085544341b51f9c935dbf6b95c76b7edfea6a0/mcp-2.2.0-py3-none-any.whl", hash = "sha256:bde982589473a060ae145e3406e9a5333fe538c97229ba841f5a7f92be004f81", size = 365656, upload-time = "2026-09-07T16:06:19.711Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/91/762d7755d971aff8a28d75f7961656148edf27875c8026e6385aaab08ae7/mcp_types-2.2.0.tar.gz", hash = "sha256:d3ed53703ddd10d9c6399f29d322bb66f3f67ab41348ac8556ba23e07fedefad", size = 65892, upload-time = "2026-09-07T16:06:25.187Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/6ffba5d8cd5dd9b8a19478875c50e04945314ba5074e84d749283f27f62d/mcp_types-2.2.0-py3-none-any.whl", hash = "sha256:ea476b73ee86709ab5abc9452385ed36cc05907e582355622e294595c9a04f13", size = 69106, upload-time = "2026-09-07T16:06:21.461Z" },
 ]
 
 [[package]]
@@ -2154,14 +2161,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.48.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Overview

## What is the feature?

Adds the ability to have authenticated tools

## What is the Solution?

Adds OAuthProxy to handle sending the user to EDL to login when a tool requires authentication.
Adds stepup.py to handle handle each request, if the tool manifest requires auth and the user does not have a token it will throw a 401 and the user will be redirected to a browser to login.
Updates terraform to route .well-known routes to the mcp target group.
Updates fastmcp to v4

## What areas of the application does this impact?

Adds the infrastructure to add authentication to a tool, but this PR does not add any authentication

## Testing

### Reproduction steps

Review `docs/developers/adding-authentication-to-a-tool.md` the add authentication to a tool and access the token from within the tool. Test in mcpinspector to verify you are redirected when trying to execute your tool.

## Pre-Review Checklist

- [ ] Added automated tests that prove the fix is effective or feature works
- [x] Verified new and existing unit tests pass locally
- [x] Performed a self-review of the code
- [x] Commented code, particularly in hard-to-understand areas
- [x] Updated corresponding documentation
- [x] Verified changes generate no new warnings
- [ ] Bumped `pyproject.toml` and `manifest.json` versions according to the [Versioning Methodology](docs/developers/versioning.md) if inputs, outputs, or logic changed
- [ ] Added any new root-level Python directories to `McpServerDockerfile` AND `McpServerDockerfile.dockerignore`
