### PR TITLE
Add a public consumer documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Consumer documentation
+
+on:
+  pull_request:
+    paths:
+      - docs/**
+      - .github/workflows/docs.yml
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+      - pyproject.toml
+      - .github/workflows/docs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: consumer-docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2
+        with:
+          version: 1.10.18
+      - name: Render public consumer documentation
+        run: quarto render docs
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: docs/_site
+
+  deploy:
+    if: github.repository == 'nasa/earthdata-mcp' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy documentation
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 An MCP (Model Context Protocol) server providing LLM agents with direct access to NASA's Common Metadata Repository (CMR). This integration enables users to agentically discover, verify, and access Earth science datasets through natural language interfaces.
 
 To start querying Earthdata immediately, see **[Connecting to the Server](#for-consumers-connecting-to-the-server)**.
-For a detailed breakdown of how tool inputs and outputs map to the underlying CMR APIs and UMM schemas, see the **[Parameter Support Reference](docs/consumers/SUPPORTED_PARAMETERS.md)**.
+The public consumer documentation is maintained in [docs/](docs/README.md#public-documentation-site).
+For a detailed breakdown of how tool inputs and outputs map to the underlying CMR APIs and UMM schemas, see the **[Parameter Support Reference](docs/consumers/supported-parameters.md)**.
 
 ### Available Tools
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+/.quarto/
+**/*.quarto_ipynb
+
+/_site/

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This directory contains detailed documentation for both consumers of the MCP ser
 
 ## For Consumers (`docs/consumers/`)
 
-This section will contain examples, sample prompts, and advanced guides for LLM agents and human developers querying the Common Metadata Repository (CMR) via this MCP server.
+This section contains examples, sample prompts, and advanced guides for LLM agents and human developers querying the Common Metadata Repository (CMR) via this MCP server.
 
 - **[User Guide](consumers/earthdata-mcp-server-user-guide.md)**: How to connect to the MCP server using variety of harnesses, example walkthrough, troubleshooting, and feedback reporting.
 - **[Currently Supported Parameters](consumers/supported-parameters.md)**: maps Earthdata MCP tool parameters to their corresponding CMR API arguments and underlying UMM schema paths.
@@ -18,3 +18,30 @@ Developer guidelines and procedures for contributing to and maintaining the appl
 - **[Versioning Methodology](developers/versioning.md)**: Explains the decoupled versioning strategy between the MCP Server (`pyproject.toml`) and individual tools (`manifest.json`).
 - **[Troubleshooting Deployments](developers/troubleshooting-deployments.md)**: Step-by-step instructions for debugging a `503 Service Unavailable` error, finding AWS CloudWatch logs, and fixing crash loops.
 - **[Integration Testing](developers/integration-testing.md)**: Instructions for running the manual integration test script against live CMR environments.
+
+## Public documentation site
+
+The Quarto project renders the existing consumer Markdown files directly, together
+with `index.qmd`. Update those source files rather than copying the guide into a
+second format. Developer and infrastructure guides remain available on GitHub and
+are not included in the public site build.
+
+Install Quarto 1.10.18, matching `.github/workflows/docs.yml`, then run from
+the repository root:
+
+```sh
+quarto preview docs
+# Build without starting a local server:
+quarto render docs
+```
+
+No Python environment, credentials, or live data queries are needed to render the
+site. Examples are displayed without execution. Generated files under `docs/_site`
+and `docs/.quarto` are ignored by Git.
+
+Pull requests build a downloadable `github-pages` artifact without deploying.
+After merge, changes to documentation or the package version rebuild and publish
+from `main`. A maintainer must first select **GitHub Actions** as the source under
+**Settings > Pages**. The deployment then publishes to
+`https://nasa.github.io/earthdata-mcp/`; the workflow does not change repository
+settings or publish from forks.

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -1,0 +1,32 @@
+project:
+  type: website
+  output-dir: _site
+  render:
+    - index.qmd
+    - consumers/*.md
+
+website:
+  title: Earthdata MCP
+  site-url: https://nasa.github.io/earthdata-mcp/
+  repo-url: https://github.com/nasa/earthdata-mcp
+  search: true
+  navbar:
+    left:
+      - href: index.qmd
+        text: Home
+      - href: consumers/earthdata-mcp-server-user-guide.md
+        text: User guide
+      - href: consumers/supported-parameters.md
+        text: Parameter reference
+    right:
+      - href: https://github.com/nasa/earthdata-mcp
+        text: GitHub
+
+format:
+  html:
+    theme: cosmo
+    toc: true
+    code-copy: true
+
+execute:
+  enabled: false

--- a/docs/consumers/earthdata-mcp-server-user-guide.md
+++ b/docs/consumers/earthdata-mcp-server-user-guide.md
@@ -1,3 +1,7 @@
+---
+pagetitle: Earthdata MCP Server User Guide
+---
+
 # Earthdata MCP Server User Guide
 
 The Earthdata MCP (Model Context Protocol) Server provides LLM agents with direct access to NASA's Common Metadata Repository (CMR). This integration enables consumers to agentically discover, verify, and access Earth science datasets through natural language interfaces like ChatGPT, Claude, etc. This guide was created to help users connect to and use the Earthdata MCP server in compatible clients.
@@ -41,6 +45,8 @@ NASA's Common Metadata Repository (CMR) organizes Earth science data into a hier
 ## Connecting a client to the MCP Server
 The Earthdata MCP server can be accessed by any MCP client that supports the Streamable HTTP transport. If you are using a client not listed below, check its documentation for configuration information.
 
+<a id="chatgptcom"></a>
+
 ### ChatGPT.com
 ChatGPT supports custom MCP server connections using Plugins in Developer Mode (not available on free plans)
 1. Open [chatgpt.com](https://chatgpt.com)
@@ -53,6 +59,8 @@ ChatGPT supports custom MCP server connections using Plugins in Developer Mode (
 8. Click **Create**
 
 After configuring the custom ChatGPT App, the **Earthdata** MCP Server (or your custom-named server) can be used in a new chat by clicking the **+** icon and selecting the server.
+
+<a id="claudeai"></a>
 
 ### Claude.ai
 1. Open [claude.ai](https://claude.ai)

--- a/docs/consumers/supported-parameters.md
+++ b/docs/consumers/supported-parameters.md
@@ -1,3 +1,7 @@
+---
+pagetitle: Supported Parameters
+---
+
 # Earthdata MCP Parameter Support Reference
 
 This reference maps Earthdata MCP tool parameters to their corresponding CMR API arguments and underlying UMM schema paths. It provides consumers with a clear picture of current API integration depth and search capabilities.
@@ -9,7 +13,7 @@ This reference maps Earthdata MCP tool parameters to their corresponding CMR API
 - [`get_tools`](#get_tools)
 - [`get_services`](#get_services)
 - [`get_keywords`](#get_keywords)
-- [`get_citations`](#get_citations) (Needs documentation)
+- `get_citations` (Needs documentation)
 
 > **Note:** All search tools globally support the `limit`, `cursor`, and `fields` parameters for pagination and response filtering. These are omitted from the tables below for brevity.
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -1,0 +1,33 @@
+---
+title: Earthdata MCP documentation
+---
+
+Connect a compatible client to NASA's Common Metadata Repository through the
+Earthdata MCP server, then discover datasets, verify data availability, and find
+access methods.
+
+## Start here
+
+The [user guide](consumers/earthdata-mcp-server-user-guide.md) covers client setup,
+example queries, authentication, limitations, and troubleshooting.
+
+The [parameter reference](consumers/supported-parameters.md) describes supported
+tool inputs and their mapping to CMR metadata.
+
+## Connection details
+
+| Setting | Value |
+| --- | --- |
+| Server URL | `https://cmr.earthdata.nasa.gov/mcp/v1` |
+| Transport | Streamable HTTP |
+| Server authentication | None |
+
+Downloading data can require a separate Earthdata Login account. See the
+[user guide's authentication section](consumers/earthdata-mcp-server-user-guide.md#authentication).
+
+## Development and feedback
+
+[Developer guides](https://github.com/nasa/earthdata-mcp/blob/main/docs/README.md)
+cover local setup, adding tools, and maintaining the service.
+
+[Report problems or suggest improvements](https://github.com/nasa/earthdata-mcp/issues).


### PR DESCRIPTION
Fixes #53.

### Changes

Add a searchable Quarto consumer site with a landing page, the existing user guide, and the parameter reference. Render the Markdown sources directly rather than duplicating their content. Fix the README's case-mismatched reference link and the guide anchors needed by the HTML renderer.

Add a pinned documentation workflow that builds PR previews and deploys only from this repository's `main` branch. Deployment permissions are confined to the deployment job; forks and pull requests cannot deploy. Examples are never executed and developer/infrastructure guides are not copied into the site.

### Validation

- Quarto 1.10.18 builds all three HTML pages successfully.
- All 81 local links/anchors resolve; the search index contains 12 entries.
- Existing example code blocks are unchanged.
- `actionlint` and `git diff --check` passed.

No application logic, API, dependencies, or package versions changed. The server suite and live client/data workflows were not run for this documentation-only change.

### Maintainer setup

GitHub Pages must use **GitHub Actions** as its source under repository Settings > Pages. After merge and deployment the site will be available at `https://nasa.github.io/earthdata-mcp/`. Repository settings and a live deployment were not changed by this PR.
